### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete regular expression for hostnames

### DIFF
--- a/ResearchStudio-Idea/skills/idea_spark/scripts/search_openalex.py
+++ b/ResearchStudio-Idea/skills/idea_spark/scripts/search_openalex.py
@@ -70,7 +70,13 @@ def work_to_record(work: dict, semantic_recall: bool = False) -> dict:
     ids = work.get('ids') or {}
     arxiv_raw = ids.get('arxiv') or ''
     # Normalize: "https://arxiv.org/abs/2412.14171" → "2412.14171"
-    arxiv_id = re.sub(r'^.*arxiv\.org/(?:abs|pdf|html)/', '', arxiv_raw).rstrip('.pdf').strip()
+    parsed_arxiv = urllib.parse.urlparse(arxiv_raw)
+    arxiv_host = (parsed_arxiv.hostname or '').lower()
+    arxiv_path = parsed_arxiv.path or ''
+    if arxiv_host in {'arxiv.org', 'www.arxiv.org'} and re.match(r'^/(?:abs|pdf|html)/', arxiv_path):
+        arxiv_id = re.sub(r'^/(?:abs|pdf|html)/', '', arxiv_path).rstrip('.pdf').strip()
+    else:
+        arxiv_id = arxiv_raw.rstrip('.pdf').strip()
     pt = work.get('primary_topic') or {}
     oa_field = ((pt.get('field') or {}).get('display_name')) or ''
     return {


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/ResearchStudio/security/code-scanning/1](https://github.com/microsoft/ResearchStudio/security/code-scanning/1)

Best fix: replace the permissive regex-based host extraction with URL parsing via `urllib.parse.urlparse`, then only strip prefixes when the hostname is exactly `arxiv.org` or `www.arxiv.org` and the path starts with `/abs/`, `/pdf/`, or `/html/`. Keep fallback behavior for already-raw IDs.

In `ResearchStudio-Idea/skills/idea_spark/scripts/search_openalex.py`, edit the `arxiv_id` normalization in `work_to_record` (around line 73).  
Implementation details:
- Parse `arxiv_raw` safely.
- If host is ArXiv and path matches expected prefixes, remove that prefix.
- Otherwise, keep original string behavior for non-URL/raw IDs.
- Preserve existing post-processing (`.rstrip('.pdf').strip()`) to avoid changing functionality broadly.

No new imports are needed since `urllib.parse` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
