### PR TITLE
fix(paper-search): bound requests and isolate source workers

### DIFF
--- a/ResearchStudio-Idea/skills/paper_search/SKILL.md
+++ b/ResearchStudio-Idea/skills/paper_search/SKILL.md
@@ -8,8 +8,8 @@ description: Search papers across arXiv, DBLP, OpenAlex, OpenReview, Semantic Sc
 Unified paper search across **arXiv**, **DBLP**, **OpenAlex**, **OpenReview**
 (NeurIPS / ICLR / ICML), **Semantic Scholar**, and **Crossref** using
 `./scripts/search_papers.py`. All sources are searched **concurrently** (in
-parallel threads) by default for maximum speed. Returns results grouped by
-source.
+independent child processes) by default for maximum speed. Queries within one
+source remain serial. Returns results grouped by source.
 
 
 ## When to use
@@ -98,6 +98,9 @@ python "$SEARCH" \
     --start-year 2024 --end-year 2026 \
     --no-parallel
 ```
+
+`--no-parallel` still uses an isolated worker process for each source, but runs
+those workers in source order instead of starting them together.
 
 Or call the function directly when more control is needed (e.g. consuming the
 structured dict rather than CLI text output). This is rarely necessary — see
@@ -218,7 +221,7 @@ following sections, in this exact order:
 
 ## Dependencies & failure modes
 
-- **arXiv**: stdlib only (uses arXiv API).
+- **arXiv**: uses the arXiv API.
 - **DBLP**: uses DBLP API.
 - **OpenAlex**: uses OpenAlex API.
 - **OpenReview**: requires `pip install openreview-py`.
@@ -229,9 +232,25 @@ following sections, in this exact order:
   and prone to hallucination. See the "Model knowledge source" section below
   for how to use it responsibly.
 
-If a source fails, `search_papers` catches the exception, prints the error, and
-continues with the remaining sources. Never retry blindly; report errors to the
-user.
+HTTP 429/500/502/503/504 responses use bounded retries. If a source still fails,
+its worker prints the error and the other source workers continue. Surface those
+errors to the user.
+
+### HTTP timeout configuration
+
+All network sources use separate connection and socket read-idle timeouts:
+
+| Environment variable | Default | Meaning |
+|:---|:---|:---|
+| `PAPER_SEARCH_CONNECT_TIMEOUT_SECONDS` | `15` | TCP/TLS connection timeout |
+| `PAPER_SEARCH_TIMEOUT_SECONDS` | `300` | Time allowed with no response bytes arriving |
+| `PAPER_SEARCH_<SOURCE>_TIMEOUT_SECONDS` | unset | Per-source read-idle override, e.g. `PAPER_SEARCH_OPEN_ALEX_TIMEOUT_SECONDS` |
+| `PAPER_SEARCH_MAX_ATTEMPTS` | `4` | Maximum attempts including the first request |
+
+Every configured value must be positive; malformed, zero, negative, NaN, or
+infinite values fail before workers start. The 300-second read timeout is not a
+total source budget: a response can take longer overall if it continues making
+socket-level progress.
 
 ## Model knowledge source
 

--- a/ResearchStudio-Idea/skills/paper_search/references/programmatic_api.md
+++ b/ResearchStudio-Idea/skills/paper_search/references/programmatic_api.md
@@ -25,3 +25,22 @@ for source, papers in res.items():
 ```
 
 Return shape: see "Output schema" in `SKILL.md`.
+
+Each selected source runs in its own child process. `parallel=False` preserves
+the same isolation while running source workers serially. For a multi-query
+call, `max_results` remains the limit for each query, and results are extended
+in query order before the existing parent-side date filtering and CLI
+post-processing.
+
+HTTP runtime settings can be exported before calling the function:
+
+```bash
+export PAPER_SEARCH_TIMEOUT_SECONDS=300
+export PAPER_SEARCH_CONNECT_TIMEOUT_SECONDS=15
+export PAPER_SEARCH_OPENREVIEW_TIMEOUT_SECONDS=600
+export PAPER_SEARCH_MAX_ATTEMPTS=4
+```
+
+The source-specific variable overrides only the socket read-idle timeout for
+that source. All values must be positive; invalid configuration raises before
+any worker starts.

--- a/ResearchStudio-Idea/skills/paper_search/scripts/_http_runtime.py
+++ b/ResearchStudio-Idea/skills/paper_search/scripts/_http_runtime.py
@@ -1,0 +1,195 @@
+"""Shared HTTP timeout and retry policy for paper-search connectors.
+
+``PAPER_SEARCH_TIMEOUT_SECONDS`` is a socket read-idle timeout, not a wall-clock
+budget for a whole source.  A response may take longer than this overall as
+long as the peer keeps delivering bytes.  ``PAPER_SEARCH_CONNECT_TIMEOUT_SECONDS``
+bounds connection establishment separately.
+"""
+
+from __future__ import annotations
+
+import functools
+import math
+import os
+import sys
+import time
+from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
+from typing import Callable, Iterable, Optional
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+DEFAULT_CONNECT_TIMEOUT_SECONDS = 15.0
+DEFAULT_READ_TIMEOUT_SECONDS = 300.0
+DEFAULT_MAX_ATTEMPTS = 4
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+@dataclass(frozen=True)
+class HTTPConfig:
+    connect_timeout: float
+    read_timeout: float
+    max_attempts: int
+
+    @property
+    def timeout(self) -> tuple[float, float]:
+        return (self.connect_timeout, self.read_timeout)
+
+
+def _positive_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a positive number of seconds, got {raw!r}") from exc
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be a positive finite number of seconds, got {raw!r}")
+    return value
+
+
+def _positive_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a positive integer, got {raw!r}") from exc
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {raw!r}")
+    return value
+
+
+def source_timeout_env(source: str) -> str:
+    return f"PAPER_SEARCH_{source.upper()}_TIMEOUT_SECONDS"
+
+
+def get_http_config(source: str) -> HTTPConfig:
+    """Resolve global and per-source settings from the current environment."""
+    global_read = _positive_float(
+        "PAPER_SEARCH_TIMEOUT_SECONDS", DEFAULT_READ_TIMEOUT_SECONDS
+    )
+    read_timeout = _positive_float(source_timeout_env(source), global_read)
+    connect_timeout = _positive_float(
+        "PAPER_SEARCH_CONNECT_TIMEOUT_SECONDS", DEFAULT_CONNECT_TIMEOUT_SECONDS
+    )
+    max_attempts = _positive_int("PAPER_SEARCH_MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS)
+    return HTTPConfig(connect_timeout, read_timeout, max_attempts)
+
+
+def validate_environment(sources: Iterable[str]) -> None:
+    """Fail before spawning workers when any selected timeout setting is invalid."""
+    for source in sources:
+        get_http_config(source)
+
+
+def create_session(user_agent: Optional[str] = None) -> requests.Session:
+    """Create a plain session; retries are applied explicitly by ``request``."""
+    session = requests.Session()
+    if user_agent:
+        session.headers["User-Agent"] = user_agent
+    return session
+
+
+def _retry_after_seconds(response: requests.Response) -> Optional[float]:
+    raw = response.headers.get("Retry-After")
+    if not raw:
+        return None
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(raw)
+            if retry_at.tzinfo is None:
+                return None
+            return max(0.0, retry_at.timestamp() - time.time())
+        except (TypeError, ValueError, OverflowError):
+            return None
+
+
+def _retry_delay(response: requests.Response, attempt: int, cap: float) -> float:
+    retry_after = _retry_after_seconds(response)
+    delay = retry_after if retry_after is not None else 3.0 * (2 ** (attempt - 1))
+    return min(cap, max(0.0, delay))
+
+
+def request(
+    session: requests.Session,
+    method: str,
+    url: str,
+    *,
+    source: str,
+    before_attempt: Optional[Callable[[], None]] = None,
+    **kwargs,
+) -> requests.Response:
+    """Issue one HTTP request with bounded status retries and socket timeouts.
+
+    Network exceptions are surfaced immediately.  Only explicit transient HTTP
+    statuses are retried, so a permanently rate-limited endpoint cannot loop
+    forever.
+    """
+    config = get_http_config(source)
+    # Connectors share one public timeout contract; a local call site cannot
+    # accidentally reintroduce an unbounded or single-value timeout.
+    kwargs["timeout"] = config.timeout
+
+    for attempt in range(1, config.max_attempts + 1):
+        if before_attempt is not None:
+            before_attempt()
+        response = session.request(method, url, **kwargs)
+        if response.status_code not in RETRYABLE_STATUS_CODES:
+            return response
+        if attempt >= config.max_attempts:
+            return response
+
+        delay = _retry_delay(response, attempt, config.read_timeout)
+        print(
+            f"[{source}] HTTP {response.status_code}; retrying in {delay:g}s "
+            f"(attempt {attempt + 1}/{config.max_attempts})",
+            file=sys.stderr,
+        )
+        response.close()
+        time.sleep(delay)
+
+    raise RuntimeError("unreachable")
+
+
+def configure_external_session(session: requests.Session, source: str) -> requests.Session:
+    """Install paper-search defaults on a requests Session owned by a dependency.
+
+    OpenReview constructs its own Session and does not expose a timeout argument.
+    Re-mounting a bounded adapter and wrapping ``Session.request`` applies the same
+    policy to authentication plus every paginated v1/v2 request.
+    """
+    config = get_http_config(source)
+    retry = Retry(
+        total=config.max_attempts - 1,
+        connect=config.max_attempts - 1,
+        read=0,
+        status=config.max_attempts - 1,
+        backoff_factor=1.5,
+        status_forcelist=sorted(RETRYABLE_STATUS_CODES),
+        allowed_methods=None,
+        redirect=0,
+        other=0,
+        raise_on_status=False,
+        respect_retry_after_header=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+
+    original_request = session.request
+
+    @functools.wraps(original_request)
+    def request_with_default_timeout(method, url, **kwargs):
+        kwargs["timeout"] = config.timeout
+        return original_request(method, url, **kwargs)
+
+    session.request = request_with_default_timeout  # type: ignore[method-assign]
+    return session

--- a/ResearchStudio-Idea/skills/paper_search/scripts/search_papers.py
+++ b/ResearchStudio-Idea/skills/paper_search/scripts/search_papers.py
@@ -12,11 +12,18 @@ prints exactly what it dropped. --raw restores the legacy per-source view.
 """
 
 import argparse
-import concurrent.futures
 import importlib
+import json
+import os
+import signal
+import subprocess
 import sys
+import tempfile
 from datetime import date, datetime
+from pathlib import Path
 from typing import Optional
+
+from _http_runtime import validate_environment
 
 # Load .env (credentials for openreview etc.) before any source runs, so the aggregator works
 # when invoked via bash without a shell-sourced .env. No-op if no .env is found.
@@ -40,6 +47,8 @@ _SOURCE_MODULE = {
     "crossref": "search_papers_by_crossref",
 }
 ALL_SOURCES = list(_SOURCE_MODULE.keys())
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_SOURCE_WORKER = _SCRIPTS_DIR / "source_worker.py"
 
 
 def _load_source_func(source: str):
@@ -50,6 +59,178 @@ def _load_source_func(source: str):
     module_name = _SOURCE_MODULE[source]
     module = importlib.import_module(module_name)
     return getattr(module, module_name)
+
+
+def _worker_command(
+    source: str,
+    queries: list[str],
+    start_year: int,
+    end_year: int,
+    max_results: int,
+    out_path: Path,
+) -> list[str]:
+    return [
+        sys.executable,
+        str(_SOURCE_WORKER),
+        "--source",
+        source,
+        "--queries-json",
+        json.dumps(queries, ensure_ascii=False),
+        "--start-year",
+        str(start_year),
+        "--end-year",
+        str(end_year),
+        "--max-results",
+        str(max_results),
+        "--out",
+        str(out_path),
+    ]
+
+
+def _start_worker(
+    source: str,
+    queries: list[str],
+    start_year: int,
+    end_year: int,
+    max_results: int,
+    work_dir: Path,
+) -> tuple[subprocess.Popen, Path, Path]:
+    out_path = work_dir / f"{source}.json"
+    log_path = work_dir / f"{source}.log"
+    command = _worker_command(
+        source, queries, start_year, end_year, max_results, out_path
+    )
+    with log_path.open("w", encoding="utf-8") as log_handle:
+        process = subprocess.Popen(
+            command,
+            cwd=str(_SCRIPTS_DIR),
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=(os.name == "posix"),
+        )
+    return process, out_path, log_path
+
+
+def _terminate_workers(processes: list[subprocess.Popen]) -> None:
+    alive = [process for process in processes if process.poll() is None]
+    for process in alive:
+        try:
+            if os.name == "posix":
+                os.killpg(process.pid, signal.SIGTERM)
+            else:
+                process.terminate()
+        except ProcessLookupError:
+            pass
+    for process in alive:
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            try:
+                if os.name == "posix":
+                    os.killpg(process.pid, signal.SIGKILL)
+                else:
+                    process.kill()
+            except ProcessLookupError:
+                pass
+    for process in alive:
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+def _collect_worker(
+    source: str,
+    process: subprocess.Popen,
+    out_path: Path,
+    log_path: Path,
+) -> list[dict]:
+    returncode = process.wait()
+    try:
+        log = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        log = f"[{source}] could not read worker log: {exc}\n"
+    if log:
+        sys.stderr.write(log)
+        if not log.endswith("\n"):
+            sys.stderr.write("\n")
+
+    if returncode != 0:
+        print(
+            f"[{source}] worker exited with status {returncode}; skipping this source.",
+            file=sys.stderr,
+        )
+        return []
+    try:
+        payload = json.loads(out_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"[{source}] worker produced no result file; skipping this source.", file=sys.stderr)
+        return []
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"[{source}] invalid worker result: {exc}; skipping this source.", file=sys.stderr)
+        return []
+
+    if not isinstance(payload, dict) or payload.get("source") != source:
+        print(f"[{source}] worker result has the wrong source; skipping it.", file=sys.stderr)
+        return []
+    papers = payload.get("papers")
+    if not isinstance(papers, list) or not all(
+        isinstance(paper, dict) for paper in papers
+    ):
+        print(f"[{source}] worker result has invalid papers; skipping it.", file=sys.stderr)
+        return []
+    return papers
+
+
+def _run_source_workers(
+    sources: list[str],
+    queries: list[str],
+    start_year: int,
+    end_year: int,
+    max_results: int,
+    parallel: bool,
+) -> dict[str, list[dict]]:
+    gathered: dict[str, list[dict]] = {}
+    with tempfile.TemporaryDirectory(prefix="paper_search_workers_") as temp_dir:
+        work_dir = Path(temp_dir)
+        states: dict[str, tuple[subprocess.Popen, Path, Path]] = {}
+        try:
+            if parallel:
+                for source in sources:
+                    try:
+                        states[source] = _start_worker(
+                            source, queries, start_year, end_year, max_results, work_dir
+                        )
+                    except OSError as exc:
+                        print(f"[{source}] worker could not start: {exc}", file=sys.stderr)
+                        gathered[source] = []
+                # Every process is already running; collecting in requested order does
+                # not serialize the network work and keeps diagnostics deterministic.
+                for source in sources:
+                    state = states.get(source)
+                    if state is not None:
+                        gathered[source] = _collect_worker(source, *state)
+            else:
+                for source in sources:
+                    try:
+                        state = _start_worker(
+                            source, queries, start_year, end_year, max_results, work_dir
+                        )
+                    except OSError as exc:
+                        print(f"[{source}] worker could not start: {exc}", file=sys.stderr)
+                        gathered[source] = []
+                        continue
+                    states[source] = state
+                    gathered[source] = _collect_worker(source, *state)
+        except BaseException:
+            _terminate_workers([state[0] for state in states.values()])
+            raise
+        finally:
+            _terminate_workers([state[0] for state in states.values()])
+
+    return {source: gathered.get(source, []) for source in sources}
+
 
 def _parse_date(value, field_name: str) -> Optional[date]:
     """Parse a YYYY-MM-DD string (or pass through date/None) for the post-filter."""
@@ -122,7 +303,7 @@ def search_papers(
         Each paper dict contains: title, authors, year, abstract, url,
         venue, citation_count, publication_date, source.
     """
-    sources = sources or ALL_SOURCES
+    sources = list(dict.fromkeys(sources or ALL_SOURCES))
     invalid = set(sources) - set(ALL_SOURCES)
     if invalid:
         raise ValueError(f"Unknown sources: {invalid}. Valid: {ALL_SOURCES}")
@@ -137,37 +318,10 @@ def search_papers(
     if start_d and end_d and start_d > end_d:
         raise ValueError(f"start_date {start_d} is after end_date {end_d}")
 
-    results: dict[str, list[dict]] = {}
-
-    def _search(source: str) -> tuple[str, list[dict]]:
-        try:
-            func = _load_source_func(source)
-        except Exception as e:
-            # Missing optional dependency for this source — skip it, keep the others working.
-            print(f"[{source}] unavailable (import failed: {e}); skipping this source.", file=sys.stderr)
-            return source, []
-        papers: list[dict] = []
-        for q in queries:
-            try:
-                papers.extend(func(q, start_year, end_year, max_results))
-            except Exception as e:
-                print(f"[{source}] Error on query {q!r}: {e}", file=sys.stderr)
-        return source, papers
-
-    if parallel:
-        gathered: dict[str, list[dict]] = {}
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(sources)) as executor:
-            futures = {executor.submit(_search, s): s for s in sources}
-            for future in concurrent.futures.as_completed(futures):
-                source, papers = future.result()
-                gathered[source] = papers
-        # Re-key in the REQUESTED order: as_completed yields in finish order,
-        # which made both the dict and the CLI printout nondeterministic.
-        results = {s: gathered.get(s, []) for s in sources}
-    else:
-        for source in sources:
-            _, papers = _search(source)
-            results[source] = papers
+    validate_environment(sources)
+    results = _run_source_workers(
+        sources, queries, start_year, end_year, max_results, parallel
+    )
 
     if start_d or end_d:
         results = {s: _filter_by_date_range(ps, start_d, end_d) for s, ps in results.items()}
@@ -253,7 +407,7 @@ if __name__ == "__main__":
         merged = dedup(results)
         ranked, n_dropped = rank(merged, query_list, min_score=args.min_score)
         n_dup = sum(per_source.values()) - len(merged)
-        print(f"\nper-source hits: " + ", ".join(f"{k}={v}" for k, v in per_source.items()))
+        print("\nper-source hits: " + ", ".join(f"{k}={v}" for k, v in per_source.items()))
         print(f"unique papers: {len(merged)} ({n_dup} cross-source duplicate records merged)")
         if n_dropped:
             print(f"DROPPED {n_dropped} paper(s) below --min-score {args.min_score} "

--- a/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_arxiv.py
+++ b/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_arxiv.py
@@ -7,12 +7,13 @@ import tempfile
 import re
 import time
 import urllib.parse
-import urllib.request
 import xml.etree.ElementTree as ET
 from datetime import datetime
 
+from _http_runtime import create_session, request
+
 # arXiv asks for no more than ~1 request every 3s. We enforce a stricter 4s floor and,
-# crucially, do it ACROSS processes: a multi-query run spawns one process per query, so an
+# crucially, do it ACROSS processes: separate paper-search invocations may overlap, so an
 # in-process lock would not help. We serialize on a lockfile in the system temp dir and hold
 # the exclusive lock across the sleep, so concurrent processes queue and each request is
 # spaced >= MIN_INTERVAL after the previous one actually fired. Override with ARXIV_MIN_INTERVAL.
@@ -68,7 +69,6 @@ def search_papers_by_arxiv(
         List of paper dictionaries.
     """
     ARXIV_API = "https://export.arxiv.org/api/query"
-    ATOM_NS = {"atom": "http://www.w3.org/2005/Atom"}
 
     date_filter = (
         f"submittedDate:[{start_year}01010000 TO {end_year}12312359]"
@@ -81,24 +81,22 @@ def search_papers_by_arxiv(
         "max_results": str(max_results),
     }
     url = ARXIV_API + "?" + urllib.parse.urlencode(params)
-    req = urllib.request.Request(url, headers={"User-Agent": "PaperSearch/1.0"})
+    session = create_session("PaperSearch/1.0")
+    response = request(
+        session,
+        "GET",
+        url,
+        source="arxiv",
+        before_attempt=_throttle,
+    )
+    response.raise_for_status()
+    xml_data = response.content.decode("utf-8")
+    return _parse_arxiv_xml(xml_data, start_year, end_year)
 
-    max_retries = 4  # initial try + 3 retries, with backoff 3s -> 6s -> 12s before giving up
-    xml_data = None
-    for attempt in range(max_retries):
-        _throttle()  # space every attempt (incl. retries) >= _MIN_INTERVAL apart, cross-process
-        try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                xml_data = resp.read().decode("utf-8")
-            break
-        except urllib.error.HTTPError as e:
-            if e.code == 429 and attempt < max_retries - 1:
-                wait = 3 * (2 ** attempt)  # 3, 6, 12
-                print(f"Rate limited, retrying in {wait}s...")
-                time.sleep(wait)
-            else:
-                raise
 
+def _parse_arxiv_xml(xml_data: str, start_year: int, end_year: int) -> list[dict]:
+    """Map an arXiv Atom response to the stable public paper schema."""
+    ATOM_NS = {"atom": "http://www.w3.org/2005/Atom"}
     root = ET.fromstring(xml_data)
     papers: list[dict] = []
 

--- a/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_crossref.py
+++ b/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_crossref.py
@@ -4,7 +4,7 @@
 import argparse
 import time
 
-import requests
+from _http_runtime import create_session, request
 
 
 def search_papers_by_crossref(
@@ -28,6 +28,7 @@ def search_papers_by_crossref(
     papers: list[dict] = []
     offset = 0
     limit = min(100, max_results)  # API max per request is 100
+    session = create_session()
 
     while len(papers) < max_results:
         params = {
@@ -42,13 +43,9 @@ def search_papers_by_crossref(
             "User-Agent": "PaperSearch/1.0 (mailto:your-email@example.com)",
         }
 
-        response = requests.get(url, params=params, headers=headers)
-
-        if response.status_code == 429:
-            print("Rate limited. Waiting 3 seconds...")
-            time.sleep(3)
-            continue
-
+        response = request(
+            session, "GET", url, source="crossref", params=params, headers=headers
+        )
         response.raise_for_status()
         data = response.json()
 

--- a/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_dblp.py
+++ b/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_dblp.py
@@ -5,7 +5,7 @@ import argparse
 import re
 import time
 
-import requests
+from _http_runtime import create_session, request
 
 
 def search_papers_by_dblp(
@@ -29,6 +29,7 @@ def search_papers_by_dblp(
     papers: list[dict] = []
     offset = 0
     limit = min(1000, max_results)  # DBLP max per request is 1000
+    session = create_session("PaperSearch/1.0")
 
     while len(papers) < max_results:
         params = {
@@ -38,13 +39,7 @@ def search_papers_by_dblp(
             "f": offset,
         }
 
-        response = requests.get(url, params=params)
-
-        if response.status_code == 429:
-            print("Rate limited. Waiting 3 seconds...")
-            time.sleep(3)
-            continue
-
+        response = request(session, "GET", url, source="dblp", params=params)
         response.raise_for_status()
         data = response.json()
 
@@ -93,7 +88,7 @@ def search_papers_by_dblp(
     # Fetch abstracts for papers that have a DOI
     papers = papers[:max_results]
     for paper in papers:
-        abstract = _fetch_abstract_from_doi(paper.get("url", ""))
+        abstract = _fetch_abstract_from_doi(paper.get("url", ""), session=session)
         if abstract:
             paper["abstract"] = abstract
         time.sleep(0.5)  # Be polite to the Crossref API
@@ -101,7 +96,7 @@ def search_papers_by_dblp(
     return papers
 
 
-def _fetch_abstract_from_doi(url: str) -> str:
+def _fetch_abstract_from_doi(url: str, session=None) -> str:
     """Try to fetch abstract from Crossref using a DOI extracted from the URL."""
     if not url:
         return ""
@@ -111,10 +106,13 @@ def _fetch_abstract_from_doi(url: str) -> str:
         return ""
     doi = match.group(1)
     try:
-        resp = requests.get(
+        session = session or create_session("PaperSearch/1.0")
+        resp = request(
+            session,
+            "GET",
             f"https://api.crossref.org/works/{doi}",
+            source="dblp",
             headers={"Accept": "application/json"},
-            timeout=10,
         )
         if resp.status_code == 200:
             data = resp.json()

--- a/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_open_alex.py
+++ b/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_open_alex.py
@@ -5,7 +5,7 @@ import argparse
 import os
 import time
 
-import requests
+from _http_runtime import create_session, request
 
 
 def search_papers_by_open_alex(
@@ -30,6 +30,7 @@ def search_papers_by_open_alex(
     papers: list[dict] = []
     page = 1
     per_page = min(200, max_results)  # API max per request is 200
+    session = create_session("PaperSearch/1.0")
 
     while len(papers) < max_results:
         params = {
@@ -42,13 +43,9 @@ def search_papers_by_open_alex(
         }
         headers = {"Authorization": f"Bearer {API_KEY}"} if API_KEY else {}
 
-        response = requests.get(url, params=params, headers=headers)
-
-        if response.status_code == 429:
-            print("Rate limited. Waiting 3 seconds...")
-            time.sleep(3)
-            continue
-
+        response = request(
+            session, "GET", url, source="open_alex", params=params, headers=headers
+        )
         response.raise_for_status()
         data = response.json()
 

--- a/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_openreview.py
+++ b/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_openreview.py
@@ -7,6 +7,8 @@ import time
 from datetime import datetime
 from typing import Optional
 
+from _http_runtime import configure_external_session
+
 # Load credentials from .env BEFORE any os.environ.get below, so OPENREVIEW_USER/PASS are
 # present even when this script is invoked directly via bash (no shell-sourced .env).
 try:
@@ -36,16 +38,37 @@ def _openreview_clients():
         import openreview
     except ImportError as e:
         raise RuntimeError("openreview not installed. pip install openreview-py") from e
-    v2 = openreview.api.OpenReviewClient(
-        baseurl="https://api2.openreview.net",
-        username=os.environ.get('OPENREVIEW_USER', ''),
-        password=os.environ.get('OPENREVIEW_PASS', ''),
+    # Instantiate anonymously so the SDK cannot perform an unbounded login before
+    # we have configured its internally-created requests Sessions.  The SDK also
+    # consults OPENREVIEW_USERNAME/PASSWORD on its own, so suppress those aliases
+    # during construction; this connector's established public names remain
+    # OPENREVIEW_USER/PASS.
+    sdk_env = {
+        name: os.environ.pop(name)
+        for name in ("OPENREVIEW_USERNAME", "OPENREVIEW_PASSWORD")
+        if name in os.environ
+    }
+    try:
+        v2 = openreview.api.OpenReviewClient(baseurl="https://api2.openreview.net")
+        v1 = openreview.Client(baseurl="https://api.openreview.net")
+    finally:
+        os.environ.update(sdk_env)
+
+    configure_external_session(v2.session, "openreview")
+    configure_external_session(v1.session, "openreview")
+
+    # Keep both the connector's documented names and the SDK aliases working.
+    # The aliases were captured above only to defer their implicit login until
+    # after the Sessions had the bounded runtime policy installed.
+    username = os.environ.get("OPENREVIEW_USER") or sdk_env.get(
+        "OPENREVIEW_USERNAME", ""
     )
-    v1 = openreview.Client(
-        baseurl="https://api.openreview.net",
-        username=os.environ.get('OPENREVIEW_USER', ''),
-        password=os.environ.get('OPENREVIEW_PASS', ''),
+    password = os.environ.get("OPENREVIEW_PASS") or sdk_env.get(
+        "OPENREVIEW_PASSWORD", ""
     )
+    if username or password:
+        v2.login_user(username=username, password=password)
+        v1.login_user(username=username, password=password)
     return v2, v1
 
 

--- a/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_semantic_scholar.py
+++ b/ResearchStudio-Idea/skills/paper_search/scripts/search_papers_by_semantic_scholar.py
@@ -5,7 +5,7 @@ import argparse
 import os
 import time
 
-import requests
+from _http_runtime import create_session, request
 
 
 def search_papers_by_semantic_scholar(
@@ -32,6 +32,7 @@ def search_papers_by_semantic_scholar(
     papers: list[dict] = []
     offset = 0
     limit = min(100, max_results)  # API max per request is 100
+    session = create_session("PaperSearch/1.0")
 
     while len(papers) < max_results:
         params = {
@@ -43,13 +44,14 @@ def search_papers_by_semantic_scholar(
         }
         headers = {"x-api-key": API_KEY} if API_KEY else {}
 
-        response = requests.get(url, params=params, headers=headers)
-
-        if response.status_code == 429:
-            print("Rate limited. Waiting 3 seconds...")
-            time.sleep(3)
-            continue
-
+        response = request(
+            session,
+            "GET",
+            url,
+            source="semantic_scholar",
+            params=params,
+            headers=headers,
+        )
         response.raise_for_status()
         data = response.json()
 

--- a/ResearchStudio-Idea/skills/paper_search/scripts/selftest_runtime.py
+++ b/ResearchStudio-Idea/skills/paper_search/scripts/selftest_runtime.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Offline regression tests for paper-search HTTP and worker isolation.
+
+Run: python3 scripts/selftest_runtime.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+import requests
+
+import _http_runtime
+import search_papers
+import search_papers_by_arxiv
+import source_worker
+import search_papers_by_openreview
+
+
+ENV_KEYS = {
+    "PAPER_SEARCH_TIMEOUT_SECONDS",
+    "PAPER_SEARCH_CONNECT_TIMEOUT_SECONDS",
+    "PAPER_SEARCH_MAX_ATTEMPTS",
+    *(f"PAPER_SEARCH_{source.upper()}_TIMEOUT_SECONDS" for source in search_papers.ALL_SOURCES),
+}
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, headers=None):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class FakeSession:
+    def __init__(self, responses=None):
+        self.responses = list(responses or [])
+        self.calls = []
+        self.mounts = {}
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return self.responses.pop(0) if self.responses else FakeResponse(200)
+
+    def mount(self, prefix, adapter):
+        self.mounts[prefix] = adapter
+
+
+class RuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self._saved_env = {key: os.environ[key] for key in ENV_KEYS if key in os.environ}
+        for key in ENV_KEYS:
+            os.environ.pop(key, None)
+
+    def tearDown(self):
+        for key in ENV_KEYS:
+            os.environ.pop(key, None)
+        os.environ.update(self._saved_env)
+
+    def test_timeout_defaults_override_and_validation(self):
+        default = _http_runtime.get_http_config("open_alex")
+        self.assertEqual(default.timeout, (15.0, 300.0))
+        self.assertEqual(default.max_attempts, 4)
+
+        os.environ["PAPER_SEARCH_TIMEOUT_SECONDS"] = "90"
+        os.environ["PAPER_SEARCH_OPEN_ALEX_TIMEOUT_SECONDS"] = "12.5"
+        os.environ["PAPER_SEARCH_CONNECT_TIMEOUT_SECONDS"] = "2"
+        overridden = _http_runtime.get_http_config("open_alex")
+        self.assertEqual(overridden.timeout, (2.0, 12.5))
+
+        os.environ["PAPER_SEARCH_MAX_ATTEMPTS"] = "0"
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            _http_runtime.validate_environment(["open_alex"])
+
+    def test_timeout_environment_rejects_every_non_positive_or_malformed_value(self):
+        numeric_keys = (
+            "PAPER_SEARCH_TIMEOUT_SECONDS",
+            "PAPER_SEARCH_CONNECT_TIMEOUT_SECONDS",
+            "PAPER_SEARCH_ARXIV_TIMEOUT_SECONDS",
+        )
+        for key in numeric_keys:
+            for value in ("", "0", "-1", "nan", "inf", "not-a-number"):
+                with self.subTest(key=key, value=value):
+                    os.environ[key] = value
+                    with self.assertRaises(ValueError):
+                        _http_runtime.validate_environment(["arxiv"])
+                    os.environ.pop(key)
+
+        for value in ("", "0", "-1", "1.5", "not-an-integer"):
+            with self.subTest(key="PAPER_SEARCH_MAX_ATTEMPTS", value=value):
+                os.environ["PAPER_SEARCH_MAX_ATTEMPTS"] = value
+                with self.assertRaises(ValueError):
+                    _http_runtime.validate_environment(["arxiv"])
+                os.environ.pop("PAPER_SEARCH_MAX_ATTEMPTS")
+
+    def test_connection_failure_is_bounded_by_connect_timeout(self):
+        session = mock.Mock()
+        session.request.side_effect = requests.exceptions.ConnectTimeout("no route")
+        with self.assertRaises(requests.exceptions.ConnectTimeout):
+            _http_runtime.request(
+                session, "GET", "https://example.invalid", source="open_alex"
+            )
+        self.assertEqual(session.request.call_count, 1)
+        self.assertEqual(session.request.call_args.kwargs["timeout"], (15.0, 300.0))
+
+    def test_retry_is_bounded_and_passes_timeout_tuple(self):
+        session = FakeSession([FakeResponse(429) for _ in range(4)])
+        with mock.patch.object(_http_runtime.time, "sleep") as sleep:
+            response = _http_runtime.request(
+                session, "GET", "https://example.invalid", source="crossref"
+            )
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(len(session.calls), 4)
+        self.assertEqual([call.args[0] for call in sleep.call_args_list], [3.0, 6.0, 12.0])
+        self.assertTrue(all(call[2]["timeout"] == (15.0, 300.0) for call in session.calls))
+
+    def test_external_session_gets_timeout_and_finite_adapter(self):
+        session = FakeSession()
+        _http_runtime.configure_external_session(session, "openreview")
+        session.request("GET", "https://example.invalid")
+        self.assertEqual(session.calls[0][2]["timeout"], (15.0, 300.0))
+        self.assertEqual(session.mounts["https://"].max_retries.total, 3)
+
+    def test_read_timeout_is_idle_not_total_duration(self):
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, _format, *_args):
+                pass
+
+            def do_GET(self):
+                body = b"abcd"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                try:
+                    for index, byte in enumerate(body):
+                        self.wfile.write(bytes([byte]))
+                        self.wfile.flush()
+                        if self.path == "/stall" and index == 0:
+                            time.sleep(0.25)
+                        elif self.path == "/progress" and index < len(body) - 1:
+                            time.sleep(0.07)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        os.environ["PAPER_SEARCH_TIMEOUT_SECONDS"] = "0.12"
+        os.environ["PAPER_SEARCH_CONNECT_TIMEOUT_SECONDS"] = "0.12"
+        os.environ["PAPER_SEARCH_MAX_ATTEMPTS"] = "1"
+        session = _http_runtime.create_session()
+        base = f"http://127.0.0.1:{server.server_port}"
+        try:
+            with self.assertRaises(requests.exceptions.RequestException):
+                _http_runtime.request(session, "GET", base + "/stall", source="arxiv")
+            response = _http_runtime.request(
+                session, "GET", base + "/progress", source="arxiv"
+            )
+            self.assertEqual(response.content, b"abcd")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+
+class WorkerTests(unittest.TestCase):
+    def test_worker_preserves_query_order_and_continues_after_error(self):
+        calls = []
+
+        def connector(query, start_year, end_year, max_results):
+            calls.append((query, start_year, end_year, max_results))
+            if query == "bad":
+                raise RuntimeError("boom")
+            return [
+                {"title": query, "source": "arxiv"},
+                {"title": "duplicate", "source": "arxiv"},
+            ]
+
+        with mock.patch.object(source_worker, "_load_source_func", return_value=connector):
+            payload = source_worker.run_source(
+                "arxiv", ["first", "bad", "last"], 2020, 2026, 7
+            )
+        self.assertEqual(
+            [paper["title"] for paper in payload["papers"]],
+            ["first", "duplicate", "last", "duplicate"],
+        )
+        self.assertEqual([call[0] for call in calls], ["first", "bad", "last"])
+        self.assertTrue(all(call[3] == 7 for call in calls))
+        self.assertEqual(payload["errors"][0]["query"], "bad")
+
+    def test_atomic_result_envelope(self):
+        payload = {"source": "arxiv", "papers": [{"title": "x"}], "errors": []}
+        with tempfile.TemporaryDirectory() as temp_dir:
+            out = Path(temp_dir) / "result.json"
+            source_worker.write_atomic(out, payload)
+            self.assertEqual(json.loads(out.read_text()), payload)
+            self.assertEqual(list(Path(temp_dir).glob("*.tmp")), [])
+
+    @staticmethod
+    def _fake_worker_command(source, queries, start_year, end_year, max_results, out_path):
+        code = (
+            "import json,sys,time; "
+            "out,source=sys.argv[1:3]; "
+            "started=time.time(); time.sleep(0.2); finished=time.time(); "
+            "json.dump({'source':source,'papers':[{'source':source,'started':started,'finished':finished}],"
+            "'errors':[]},open(out,'w'))"
+        )
+        return [sys.executable, "-c", code, str(out_path), source]
+
+    def test_sources_overlap_in_parallel_and_serialize_when_disabled(self):
+        sources = ["arxiv", "dblp"]
+        with mock.patch.object(search_papers, "_worker_command", self._fake_worker_command):
+            parallel = search_papers._run_source_workers(
+                sources, ["q"], 2020, 2026, 1, parallel=True
+            )
+            serial = search_papers._run_source_workers(
+                sources, ["q"], 2020, 2026, 1, parallel=False
+            )
+        first_p, second_p = parallel["arxiv"][0], parallel["dblp"][0]
+        self.assertLess(max(first_p["started"], second_p["started"]), min(first_p["finished"], second_p["finished"]))
+        first_s, second_s = serial["arxiv"][0], serial["dblp"][0]
+        self.assertGreaterEqual(second_s["started"], first_s["finished"])
+        self.assertEqual(list(parallel), sources)
+
+    def test_worker_crash_and_invalid_json_do_not_cancel_other_sources(self):
+        def command(source, queries, start_year, end_year, max_results, out_path):
+            if source == "arxiv":
+                return [sys.executable, "-c", "raise SystemExit(7)"]
+            if source == "dblp":
+                return [
+                    sys.executable,
+                    "-c",
+                    "import sys; open(sys.argv[1],'w').write('not json')",
+                    str(out_path),
+                ]
+            if source == "open_alex":
+                return [sys.executable, "-c", "raise SystemExit(0)"]
+            code = (
+                "import json,sys; out,source=sys.argv[1:3]; "
+                "json.dump({'source':source,'papers':[{'title':'ok'}],'errors':[]},open(out,'w'))"
+            )
+            return [sys.executable, "-c", code, str(out_path), source]
+
+        sources = ["arxiv", "dblp", "open_alex", "crossref"]
+        with mock.patch.object(search_papers, "_worker_command", command):
+            result = search_papers._run_source_workers(
+                sources, ["q"], 2020, 2026, 1, parallel=True
+            )
+        self.assertEqual(result["arxiv"], [])
+        self.assertEqual(result["dblp"], [])
+        self.assertEqual(result["open_alex"], [])
+        self.assertEqual(result["crossref"], [{"title": "ok"}])
+
+    def test_interrupt_terminates_all_started_workers(self):
+        started = []
+        original_start = search_papers._start_worker
+
+        def command(_source, _queries, _start_year, _end_year, _max_results, _out):
+            return [sys.executable, "-c", "import time; time.sleep(30)"]
+
+        def recording_start(*args, **kwargs):
+            state = original_start(*args, **kwargs)
+            started.append(state[0])
+            return state
+
+        with mock.patch.object(search_papers, "_worker_command", command), mock.patch.object(
+            search_papers, "_start_worker", side_effect=recording_start
+        ), mock.patch.object(
+            search_papers, "_collect_worker", side_effect=KeyboardInterrupt
+        ):
+            with self.assertRaises(KeyboardInterrupt):
+                search_papers._run_source_workers(
+                    ["arxiv", "dblp"], ["q"], 2020, 2026, 1, parallel=True
+                )
+
+        self.assertEqual(len(started), 2)
+        self.assertTrue(all(process.poll() is not None for process in started))
+
+    def test_public_api_keeps_order_and_applies_date_filter_after_workers(self):
+        raw = {
+            "dblp": [{"title": "old", "publication_date": "2023-01-01"}],
+            "arxiv": [{"title": "new", "publication_date": "2025-02-01"}],
+        }
+        with mock.patch.object(search_papers, "_run_source_workers", return_value=raw):
+            result = search_papers.search_papers(
+                "q",
+                2023,
+                2025,
+                sources=["dblp", "arxiv"],
+                start_date="2024-01-01",
+            )
+        self.assertEqual(list(result), ["dblp", "arxiv"])
+        self.assertEqual(result["dblp"], [])
+        self.assertEqual(result["arxiv"][0]["title"], "new")
+
+    def test_invalid_runtime_configuration_fails_before_starting_workers(self):
+        with mock.patch.dict(
+            os.environ, {"PAPER_SEARCH_TIMEOUT_SECONDS": "invalid"}, clear=False
+        ), mock.patch.object(search_papers, "_run_source_workers") as run_workers:
+            with self.assertRaises(ValueError):
+                search_papers.search_papers(
+                    "q", 2023, 2025, sources=["arxiv"], parallel=True
+                )
+        run_workers.assert_not_called()
+
+
+class OpenReviewTests(unittest.TestCase):
+    def test_clients_are_configured_before_explicit_login(self):
+        created = []
+
+        class Client:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.session = FakeSession()
+                self.logins = []
+                created.append(self)
+
+            def login_user(self, **kwargs):
+                self.logins.append(kwargs)
+                self.session.request("POST", self.kwargs["baseurl"] + "/login")
+
+        fake_openreview = type(
+            "FakeOpenReview",
+            (), {"api": type("API", (), {"OpenReviewClient": Client}), "Client": Client},
+        )
+        env = {"OPENREVIEW_USER": "user", "OPENREVIEW_PASS": "pass"}
+        with mock.patch.dict(sys.modules, {"openreview": fake_openreview}), mock.patch.dict(
+            os.environ, env, clear=False
+        ):
+            v2, v1 = search_papers_by_openreview._openreview_clients()
+
+        self.assertEqual(len(created), 2)
+        self.assertTrue(all(set(client.kwargs) == {"baseurl"} for client in created))
+        self.assertEqual(v2.logins, [{"username": "user", "password": "pass"}])
+        self.assertEqual(v1.logins, [{"username": "user", "password": "pass"}])
+        self.assertTrue(
+            all(client.session.calls[0][2]["timeout"] == (15.0, 300.0) for client in created)
+        )
+        v2.session.request("GET", "https://example.invalid")
+        self.assertEqual(v2.session.calls[-1][2]["timeout"], (15.0, 300.0))
+
+    def test_full_recall_path_still_uses_get_all_notes(self):
+        note = object()
+
+        class V2:
+            def get_all_notes(self, **kwargs):
+                self.kwargs = kwargs
+                return [note]
+
+        class V1:
+            def get_all_notes(self, **_kwargs):
+                raise AssertionError("v1 fallback should not run")
+
+        v2 = V2()
+        self.assertEqual(
+            search_papers_by_openreview._fetch_venue_notes(v2, V1(), "Venue"),
+            [note],
+        )
+        self.assertEqual(v2.kwargs, {"content": {"venueid": "Venue"}})
+
+
+class ArxivSchemaTests(unittest.TestCase):
+    def test_mock_response_matches_legacy_fixture_output(self):
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+          <entry>
+            <id>https://arxiv.org/abs/2401.12345v2</id>
+            <published>2024-01-20T00:00:00Z</published>
+            <title> A Test Paper </title>
+            <summary> Abstract body. </summary>
+            <author><name>Alice</name></author>
+            <author><name>Bob</name></author>
+            <arxiv:doi>10.1000/test</arxiv:doi>
+          </entry>
+        </feed>"""
+        response = mock.Mock()
+        response.content = xml.encode("utf-8")
+        with mock.patch.object(
+            search_papers_by_arxiv, "request", return_value=response
+        ) as request:
+            papers = search_papers_by_arxiv.search_papers_by_arxiv(
+                "test query", 2024, 2026, 10
+            )
+        response.raise_for_status.assert_called_once_with()
+        self.assertEqual(request.call_args.kwargs["source"], "arxiv")
+        self.assertIs(request.call_args.kwargs["before_attempt"], search_papers_by_arxiv._throttle)
+        self.assertEqual(
+            papers,
+            [{
+                "title": "A Test Paper",
+                "authors": ["Alice", "Bob"],
+                "year": 2024,
+                "abstract": "Abstract body.",
+                "url": "https://arxiv.org/abs/2401.12345v2",
+                "venue": "arXiv",
+                "citation_count": 0,
+                "publication_date": "2024-01-20",
+                "source": "arxiv",
+                "doi": "10.1000/test",
+                "arxiv_id": "2401.12345",
+            }],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ResearchStudio-Idea/skills/paper_search/scripts/source_worker.py
+++ b/ResearchStudio-Idea/skills/paper_search/scripts/source_worker.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Run exactly one paper-search connector and atomically persist its result."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from _env import load_env_once
+    load_env_once()
+except Exception:
+    pass
+
+from _http_runtime import validate_environment
+from search_papers import ALL_SOURCES, _load_source_func
+
+
+def _error(query, exc: Exception) -> dict:
+    return {
+        "query": query,
+        "type": type(exc).__name__,
+        "message": str(exc),
+    }
+
+
+def run_source(
+    source: str,
+    queries: list[str],
+    start_year: int,
+    end_year: int,
+    max_results: int,
+) -> dict:
+    """Mirror search_papers' historical per-source, per-query behavior."""
+    papers: list[dict] = []
+    errors: list[dict] = []
+    try:
+        # Imports are connector execution too: keep any dependency warnings or
+        # incidental prints out of stdout just like the search call itself.
+        with contextlib.redirect_stdout(sys.stderr):
+            func = _load_source_func(source)
+    except Exception as exc:
+        print(
+            f"[{source}] unavailable (import failed: {exc}); skipping this source.",
+            file=sys.stderr,
+        )
+        errors.append(_error(None, exc))
+        return {"source": source, "papers": papers, "errors": errors}
+
+    for query in queries:
+        try:
+            # A connector must never share stdout with the machine-readable result.
+            with contextlib.redirect_stdout(sys.stderr):
+                papers.extend(func(query, start_year, end_year, max_results))
+        except Exception as exc:
+            print(f"[{source}] Error on query {query!r}: {exc}", file=sys.stderr)
+            errors.append(_error(query, exc))
+
+    return {"source": source, "papers": papers, "errors": errors}
+
+
+def write_atomic(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False)
+            handle.write("\n")
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True, choices=ALL_SOURCES)
+    parser.add_argument("--queries-json", required=True)
+    parser.add_argument("--start-year", required=True, type=int)
+    parser.add_argument("--end-year", required=True, type=int)
+    parser.add_argument("--max-results", default=10, type=int)
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+
+    queries = json.loads(args.queries_json)
+    if not isinstance(queries, list) or not queries or not all(
+        isinstance(query, str) and query for query in queries
+    ):
+        parser.error("--queries-json must be a non-empty JSON array of strings")
+    if args.max_results < 0:
+        parser.error("--max-results must be >= 0")
+
+    validate_environment([args.source])
+    payload = run_source(
+        args.source, queries, args.start_year, args.end_year, args.max_results
+    )
+    write_atomic(args.out, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add shared, configurable connect/read timeouts and bounded retries for paper-search HTTP requests, including arXiv and OpenReview
- run each selected source in an isolated worker process so crashes, malformed results, and interrupts do not affect other sources

## Details

- defaults to a 15-second connect timeout, 300-second socket read-idle timeout, and four total attempts
- supports global and per-source timeout overrides with fail-fast validation
- retries only HTTP 429/500/502/503/504 with finite backoff
- keeps queries within a source serial while sources run concurrently by default
- uses atomic JSON result envelopes and forwards connector diagnostics to stderr
- terminates and reaps live workers on Ctrl-C
- preserves `search_papers()` and CLI arguments, paper fields, per-query limits, source order, date filtering, raw output, deduplication, and ranking behavior
- preserves OpenReview `get_all_notes()` full-recall behavior and applies the runtime policy to anonymous, login, and paginated requests

## Configuration

```text
PAPER_SEARCH_TIMEOUT_SECONDS=300
PAPER_SEARCH_CONNECT_TIMEOUT_SECONDS=15
PAPER_SEARCH_<SOURCE>_TIMEOUT_SECONDS
PAPER_SEARCH_MAX_ATTEMPTS=4
```

`PAPER_SEARCH_TIMEOUT_SECONDS` is a socket read-idle timeout, not a total source deadline.

## Validation

- `selftest_runtime.py`: 16/16 passed
- `selftest_postprocess.py`: 15/15 passed
- changed-file Ruff checks passed
- all paper-search scripts compile with `py_compile`
- `git diff --check` passed
- live multi-source search completed while isolating transient 429/503/504 source failures
