### PR TITLE
fix(paper2assets): rasterize figure PDFs at CropBox, not MediaBox

### DIFF
--- a/ResearchStudio-Reel/skills/paper2assets/scripts/source_figures.py
+++ b/ResearchStudio-Reel/skills/paper2assets/scripts/source_figures.py
@@ -205,9 +205,13 @@ def rasterize(src: Path, dst: Path, dpi: int = 432) -> tuple[int, int] | None:
                     else ["gs", "-q", "-dNOPAUSE", "-dBATCH", "-sDEVICE=pdfwrite",
                           f"-sOutputFile={pdf}", str(src)])
             subprocess.run(tool, capture_output=True, timeout=120)
-        # vector pdf -> png via pdftoppm (first page)
+        # vector pdf -> png via pdftoppm (first page).
+        # -cropbox: rasterize the CropBox (what \includegraphics shows in the paper),
+        # NOT the full MediaBox. Figure PDFs whose CropBox < MediaBox carry leftover /
+        # off-canvas content outside the visible crop (e.g. an unused panel parked in
+        # the page margin); without -cropbox that junk leaks into the extracted figure.
         prefix = dst.with_suffix("")
-        subprocess.run(["pdftoppm", "-png", "-r", str(dpi), "-singlefile",
+        subprocess.run(["pdftoppm", "-cropbox", "-png", "-r", str(dpi), "-singlefile",
                         str(pdf), str(prefix)], capture_output=True, timeout=120, check=True)
         if pdf != src:
             pdf.unlink(missing_ok=True)


### PR DESCRIPTION
## Problem
`paper2assets` `source_figures.py:rasterize()` rasterized figure PDFs with `pdftoppm` at the **MediaBox** (full page). When a figure PDF's **CropBox** is smaller than its MediaBox, the region outside the crop (leftover / off-canvas content the author parked in the page margin) got rendered into the extracted figure PNG. The paper itself never shows that region, because `\includegraphics` honors the CropBox.

## Repro
arXiv:2507.04036 (PresentAgent), Figure 4 = `figs/overview.pdf`:
- MediaBox `595.22 x 842`, CropBox `327.52 x 520.5`
- Extracted `figure4.png` included two stray panels ("Via Fixed Quiz" + Content/Visual/Comprehension Quality bars) that are **not** in the published Figure 4 — they sit outside the CropBox in the page margin.
- This then flowed straight into a generated poster.

## Fix
Add `-cropbox` to the `pdftoppm` call so it rasterizes the CropBox (exactly what `\includegraphics` shows). No-op for figures where CropBox == MediaBox; strictly better otherwise. Verified: `overview.pdf` now renders the compact figure with no off-canvas junk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)