### PR TITLE
fix(paper2poster): adapt narration play buttons per template

### DIFF
--- a/ResearchStudio-Reel/skills/paper2poster/assets/headers/v4.html
+++ b/ResearchStudio-Reel/skills/paper2poster/assets/headers/v4.html
@@ -108,7 +108,13 @@
   .titlebar .listen-all {
     position: absolute;
     bottom: 16pt;
-    left: 56pt;
+    /* v4's title is a single left-aligned line and the authors/legend below it
+       are short + left-anchored, so the band UNDER the title (right of that
+       short text, left of the right-hand mark-stack) is empty. Center Full
+       Listen there — full size, NO extra header height. */
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
     z-index: 5;
     font-size: 26pt;
     font-weight: 600;

--- a/ResearchStudio-Reel/skills/paper2poster/assets/styles/double-rule.css
+++ b/ResearchStudio-Reel/skills/paper2poster/assets/styles/double-rule.css
@@ -10,5 +10,19 @@
   margin: 0 0 0.45em 0; font-size: 60pt; line-height: 1.1; font-weight: 800;
   text-align:center; border-top:2.5pt solid var(--accent); border-bottom:2.5pt solid var(--accent); padding:0.14em 0 !important;
   /* !important resets the layout base `.section h2{padding-right:5.5em}` (Listen-button reservation) to 0
-     so the title is truly centred between the two rules (the button is absolute at the card corner). */
+     so the title is truly centred between the two rules. */
 }
+/* Per-section Listen button sits IN THE MIDDLE of the double-rule band: made
+   inline (not absolute) so it flows right after the centred title and the whole
+   "Title  ▶Listen" reads as one centred unit between the two rules. It is
+   display:none while the controls are hidden so it reserves NO width — the
+   printed title stays perfectly centred — and reflows in only when show-listen
+   reveals the narration UI. */
+.section h2 .listen-btn {
+  position: static;
+  display: none;
+  vertical-align: middle;
+  margin-left: 0.55em;
+  top: auto; right: auto; left: auto; transform: none;
+}
+body.show-listen .section h2 .listen-btn { display: inline-block; }

--- a/ResearchStudio-Reel/skills/paper2poster/assets/styles/framed.css
+++ b/ResearchStudio-Reel/skills/paper2poster/assets/styles/framed.css
@@ -54,3 +54,21 @@
     background: var(--section-accent, var(--accent));
     border-radius: 14pt 14pt 0 0;
   }
+  /* Per-section Listen button lands ON the accent banner (top-right). The base
+     accent-fill pill would read accent-on-accent (low contrast), so INVERT it
+     here: white pill + accent glyph while idle so it pops off the banner, then
+     flip to the accent fill (white border keeps it legible) while hovered /
+     playing. The base top:32pt sits it a touch low on the one-line banner, so
+     raise it to vertically centre on the banner. */
+  .section h2 .listen-btn {
+    top: 17pt;
+    background: #ffffff;
+    color: var(--section-accent, var(--accent));
+    border-color: rgba(255, 255, 255, 0.95);
+  }
+  .section h2 .listen-btn:hover,
+  .section h2 .listen-btn.playing {
+    background: var(--section-accent, var(--accent));
+    color: #ffffff;
+    border-color: #ffffff;
+  }

--- a/ResearchStudio-Reel/skills/paper2poster/assets/styles/legend-frame.css
+++ b/ResearchStudio-Reel/skills/paper2poster/assets/styles/legend-frame.css
@@ -7,17 +7,23 @@
   background:#fff; border:3pt solid var(--accent); border-radius:10pt;
 }
 .section h2 {
-  position: absolute; top: 0; left: 50%; transform: translate(-50%, -50%);
-  margin: 0; padding: 5pt 20pt !important;   /* !important beats the layout base `.section h2{padding-right:5.5em}`
-                                                (Listen-button reservation) so the pill stays symmetric and the
-                                                title is truly centred in BOTH the white pill and the frame */
-  display: flex; align-items: center; justify-content: center;   /* center the title IN its white pill (both axes) */
+  /* Static (was position:absolute) so the per-section Listen button — an h2
+     child — takes the .section as its containing block instead of this small
+     centred pill, letting it sit at the section's FAR-RIGHT corner rather than
+     hugging the title. The pill still straddles the frame's top edge and
+     centres horizontally: align-self:center sizes it to the title text, and a
+     negative top margin pulls it up ~half its own height above the border. */
+  align-self: center;
+  margin: -73pt 0 0.5em 0;
+  padding: 5pt 20pt !important;   /* !important beats the layout base `.section h2{padding-right:5.5em}` so the pill hugs the title symmetrically */
   background: #fff; font-size: 50pt; line-height: 1.05; font-weight: 800;
-  text-align: center; white-space: nowrap;                       /* ONE line — the pill widens to the title; with the
-                                                                    Listen button dropped (below) it stays narrow enough to fit */
+  text-align: center; white-space: nowrap;                       /* ONE line — the pill widens to the title */
 }
-/* The per-section Listen button lives INSIDE the <h2> (`<h2>Problem <button.listen-btn>…`)
-   and is only visibility:hidden by default, so it still OCCUPIES width — inside this centred
-   pill it shoves the title off-centre AND pads the line so a title that would fit on one line
-   wraps. Drop it from the legend-frame pill so the white box hugs the title text alone. */
-.section h2 .listen-btn { display: none; }
+/* Now that the h2 is static, the button anchors to the .section: place it at
+   the far top-right inside the frame, clear of the centred legend pill. */
+.section h2 .listen-btn {
+  top: 24pt;
+  right: 26pt;
+  left: auto;
+  transform: none;
+}

--- a/ResearchStudio-Reel/skills/paper2poster/assets/styles/tag.css
+++ b/ResearchStudio-Reel/skills/paper2poster/assets/styles/tag.css
@@ -10,9 +10,23 @@
   margin: 0 0 0.45em 0; font-size: 60pt; line-height: 1.1; font-weight: 800;
   align-self:flex-start; background:var(--accent); color:#fff; padding:0.1em 0.42em !important; border-radius:8pt;
 }
-/* The shared base rule reserves padding-right:5.5em on every section h2 for the
-   per-section Listen button; on the tag pill that stretches the accent
-   background ~5.5em past the heading text ("[Text      ]"). The padding override
-   above makes the pill hug the text; dropping the button here removes the width
-   it would otherwise reserve inside the pill. */
-.section h2 .listen-btn { display: none !important; }
+/* Per-section Listen button: this h2 is a STATIC flex-start pill (not
+   positioned), so the absolutely-positioned .listen-btn anchors to the
+   .section (position:relative) and lands at the section's top-RIGHT corner —
+   clear of the top-LEFT accent tag pill. Keep it visible so this style shares
+   the same play-control vocabulary as every other style (was display:none).
+   The base pill is an accent FILL, identical to the filled accent title pill,
+   so on this style the two read as duplicates. Differentiate the button as an
+   OUTLINED white pill (accent stroke + glyph) so it stays clearly a control,
+   not a second heading tag; hover / playing flips it to the accent fill. */
+.section h2 .listen-btn {
+  background: #fff;
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.section h2 .listen-btn:hover,
+.section h2 .listen-btn.playing {
+  background: var(--accent);
+  color: #fff;
+  border-color: #fff;
+}


### PR DESCRIPTION
## What

Adapts the narration play buttons in `paper2poster` so they fit every block
style and title template instead of sitting at one fixed spot.

- **tag**: re-enable the per-section Listen button (was `display:none`) as an
  outlined white pill, distinct from the filled accent title pill.
- **legend-frame**: re-enable it; `h2` made static so the button anchors to
  the `.section` and sits at the far top-right instead of hugging the pill.
- **double-rule**: button is inline after the centred title, so "Title Listen"
  centres as one unit between the rules; hidden state reserves no width, so the
  printed title stays centred.
- **framed**: white pill with accent glyph, vertically centred on the banner.
- **header v4**: Full Listen centred in the empty band below the single-line
  title, clearing authors/legend and logos with no added header height.

The other 7 styles and headers v1/v2/v3/v5 were already correct and are
unchanged. Verified by rendering every style x header with `body.show-listen`.
