### PR TITLE
fix: show correct default choice in install.sh prompt hint

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -92,7 +92,8 @@ ask_yn() {
   if [ "$NONINTERACTIVE" = 1 ] || [ ! -t 0 ]; then
     [ "$def" = "Y" ] && return 0 || return 1
   fi
-  local hint="[y/n]"; [ "$def" = "N" ] && hint="[y/n]"
+  local hint="[Y/n]"
+  [ "$def" = "N" ] && hint="[y/N]"
   printf '\033[1m%s %s \033[0m' "$q" "$hint"
   read -r ans || true
   ans="${ans:-$def}"


### PR DESCRIPTION
Fix the default prompt display in install.sh so yes/no questions now show the correct default state: 
[Y/n] for default yes and [y/N] for default no. This keeps the existing input behavior unchanged while making the installer prompts clearer and less error-prone for users.