### PR TITLE
Harden Paper2Video contracts and Paper2Reel delivery

### DIFF
--- a/ResearchStudio-Reel/skills/paper2reel/README.md
+++ b/ResearchStudio-Reel/skills/paper2reel/README.md
@@ -34,7 +34,8 @@ Written back into the same v2 bundle root:
 | `assets/media/` | Video assets, section clips, VTT captions, and media metadata |
 | `assets/slides/` | Slide thumbnails / frames used for timeline navigation |
 | `assets/blog/` | HTML-rendered blog blocks and embedded blog images |
-| `assets/downloads/` | User-facing download bundle links |
+| `assets/meta/reel_downloads.json` | Structured All/Poster/Video/Blog source manifest |
+| `assets/downloads/` | Persisted ZIPs in standalone `materialized` mode only |
 
 `video_no_subtitles.mp4` is the playback source for the reel. The final subtitled `video.mp4` remains downloadable, but using it for in-reel playback would double-subtitle once the viewer CC toggle is enabled.
 
@@ -57,15 +58,19 @@ python skills/paper2reel/scripts/serve_reel.py ./my_paper/ --port 8900
 ```
 
 Open `http://127.0.0.1:8900/reel.html`. Do not use `python -m http.server` for validation; video seek requires HTTP Range support.
+The same server handles `__download__/{all,poster,video,blog}` for
+`on_demand` bundles and streams a temporary ZIP from
+`assets/meta/reel_downloads.json` without saving it in the bundle.
 
 The generated `reel.html` also supports direct local opening. You may double-click
 `reel.html` or open it through `file://` as long as the whole v2 bundle folder is
 kept together. Under `file://`, the viewer embeds the copied poster through
 `iframe.srcdoc`, localizes poster render resources such as MathJax into
 `assets/poster/`, and keeps the same poster hover, section modal, captions,
-blog, thumbnails, shortcuts, and downloads UI. The HTTP server remains the
-golden preview path for Range/206 validation; direct-open mode is validated by a
-separate file-browser gate.
+blog, thumbnails, and shortcuts. Standalone `materialized` bundles keep their
+offline ZIP links; `on_demand` bundles hide those online-only links under
+`file://`. The HTTP server remains the golden preview path for Range/206
+validation; direct-open mode is validated by a separate file-browser gate.
 
 ## How it works
 
@@ -82,6 +87,10 @@ separate file-browser gate.
 The default view is poster-first. Sections highlight on hover; double-clicking a poster section opens the section modal. The title region opens the full-paper modal. The modal places video on the left and blog on the right, with a draggable split, subtitle toggle, slide thumbnails that seek the video, and direct progress-bar seeking. Keyboard shortcuts include audio, help, and top-menu controls.
 
 Downloads and the top menu are part of the delivered UI, not optional extras.
+The explicit manifest field `delivery` selects `materialized` (default,
+persisted ZIPs) or `on_demand` (dynamic endpoint, no persisted ZIPs). Portal
+jobs must invoke `build_reel_from_paper.py --download-mode on_demand`; normal
+standalone use remains backward-compatible.
 
 ## Scripts
 
@@ -91,6 +100,7 @@ scripts/
 ├── build_poster_slides_view.py       # poster + slides base viewer
 ├── build_section_media_from_timeline.py # section clips/captions from video timeline
 ├── check_reel_package.py             # browser-backed hard QA gate
+├── reel_downloads.py                 # shared manifest/path/archive contract
 └── serve_reel.py                     # Range-capable local preview server
 ```
 

--- a/ResearchStudio-Reel/skills/paper2reel/SKILL.md
+++ b/ResearchStudio-Reel/skills/paper2reel/SKILL.md
@@ -160,8 +160,13 @@ store section-level EN/CN blocks in `content_alignment.json`; the browser gate
 requires those blocks.
 
 When download directories are provided, the builder creates top-menu download
-links for the exact deliverable bundles shown in the viewer. The menu is still
-hidden by default and appears with `v`.
+links for the exact deliverable bundles shown in the viewer. `poster_final.zip`,
+`video_final.zip`, and `blog_final.zip` contain only their module's final
+deliverables; `all_final.zip` is their deduplicated union. Rebuilding in a
+shared v2 bundle must exclude `.claude/`, backup files, and
+`assets/downloads/` so archives never contain old archives or grow
+recursively. The final checker validates those archive boundaries. The menu is
+still hidden by default and appears with `v`.
 
 ## Timeline-Backed Section Media
 

--- a/ResearchStudio-Reel/skills/paper2reel/SKILL.md
+++ b/ResearchStudio-Reel/skills/paper2reel/SKILL.md
@@ -94,7 +94,9 @@ Build the user-facing viewer directly in a v2 reel bundle:
     media/
     slides/
     blog/
-    downloads/
+    meta/
+      reel_downloads.json
+    downloads/                           # materialized mode only
 ```
 
 This directory must be self-contained enough to serve locally: `reel.html`
@@ -117,6 +119,7 @@ python skills/paper2reel/scripts/build_poster_slides_view.py \
   --download-poster-dir <poster_outdir> \
   --download-blog-dir <blog_outdir> \
   --download-video-dir <video_outdir> \
+  --download-mode materialized \
   --outdir <reel_outdir>
 ```
 
@@ -142,7 +145,9 @@ The script writes:
     blog/
       figures/
         ...
-    downloads/
+    meta/
+      reel_downloads.json
+    downloads/                       # materialized mode only
       all_final.zip
       poster_final.zip
       blog_final.zip
@@ -159,14 +164,27 @@ figure directory. The builder will copy blog figures into `blog/figures/` and
 store section-level EN/CN blocks in `content_alignment.json`; the browser gate
 requires those blocks.
 
-When download directories are provided, the builder creates top-menu download
-links for the exact deliverable bundles shown in the viewer. `poster_final.zip`,
-`video_final.zip`, and `blog_final.zip` contain only their module's final
-deliverables; `all_final.zip` is their deduplicated union. Rebuilding in a
-shared v2 bundle must exclude `.claude/`, backup files, and
-`assets/downloads/` so archives never contain old archives or grow
-recursively. The final checker validates those archive boundaries. The menu is
-still hidden by default and appears with `v`.
+When download directories are provided, the builder always writes
+`assets/meta/reel_downloads.json` with schema
+`paper2reel.downloads.v1`. Its `archives` object contains exactly `all`,
+`poster`, `video`, and `blog`; every archive declares `label`, `filename`, and
+deduplicated `files` entries with bundle-relative POSIX `path`, ZIP `arcname`,
+and exact byte `size`.
+
+Download delivery has two explicit modes:
+
+- `materialized` is the standalone default. It preserves
+  `assets/downloads/{all,poster,video,blog}_final.zip` and full `file://`
+  download behavior.
+- `on_demand` writes no persistent ZIP. It uses relative
+  `__download__/{all,poster,video,blog}` links, which `serve_reel.py` resolves
+  from the manifest and streams as temporary ZIP responses. Direct `file://`
+  opening hides these online-only links.
+
+Both modes exclude `.claude/`, nested download directories, backups, and
+internal files. On-demand module entries are whitelisted and `all` is their
+deduplicated union. Use `on_demand` for Portal jobs and `materialized` for
+standalone offline bundles unless the caller explicitly chooses otherwise.
 
 ## Timeline-Backed Section Media
 
@@ -245,6 +263,12 @@ download pill with icon and `All | Poster | Video | Blog` links, section-rail
 hover styling, section clip, raw pre-subtitle playback video, toggleable VTT
 captions, blog images, or the fixed template/version markers.
 
+Download QA follows the manifest's explicit `delivery` field. In
+`materialized` mode it validates the four ZIPs using the existing archive
+boundaries. In `on_demand` mode it rejects persisted ZIPs, validates every
+manifest path, classification, source file, and byte size, checks the
+deduplicated All union, and probes each dynamic endpoint with HTTP HEAD.
+
 If the checker fails, treat it as an agent repair task first: fix the viewer and
 rerun the gate. Do not mark the stage `PASS` and do not ask the user to catch it
 by visually inspecting the page.
@@ -257,6 +281,9 @@ python skills/paper2reel/scripts/serve_reel.py <reel_outdir> --port 8900
 
 Open `http://127.0.0.1:8900/reel.html`. The preview is not considered faithful
 unless video requests return `206 Partial Content` for Range requests.
+For `on_demand` bundles this server also implements
+`/__download__/{all,poster,video,blog}` and creates each ZIP only for the
+request; it does not write archives into the bundle.
 
 For quick local sharing, users may also double-click `<reel_outdir>/reel.html`.
 Do not remove the `assets/` folder or copy only the HTML file; direct-open mode
@@ -267,6 +294,7 @@ still depends on the v2 bundle folder structure.
 `<reel_outdir>/manifest.json` must include `"layout": "v2-assets"` and
 root-relative paths for `reel.html`, `content_alignment.json`,
 `assets/poster/`, `assets/media/`, `assets/slides/`, `assets/blog/`, and
+`assets/meta/reel_downloads.json`. Materialized bundles also index
 `assets/downloads/`. Keep QA screenshots and reports under
 `assets/meta/previews/` and `assets/meta/reports/`.
 
@@ -313,8 +341,16 @@ Then follow its stage report:
 - When all upstream stages pass, let the helper assemble the reel:
 
   ```bash
-  python skills/paper2reel/scripts/build_reel_from_paper.py <paper.pdf-or-bundle> --run-missing
+  python skills/paper2reel/scripts/build_reel_from_paper.py \
+    <paper.pdf-or-bundle> \
+    --run-missing \
+    --download-mode materialized
   ```
+
+  Portal callers must pass `--download-mode on_demand`. After the staged Reel
+  is synchronized into the final shared bundle, the helper rebuilds the
+  manifest against that final bundle and removes any historical
+  `assets/downloads/` directory.
 
 The helper builds the viewer in a temporary staging directory and then copies
 only the reel deliverables back into the v2 bundle. This avoids the
@@ -322,7 +358,8 @@ only the reel deliverables back into the v2 bundle. This avoids the
 poster, blog, video, or paper2assets outputs. It preserves the v2 contract:
 `reel.html` and `content_alignment.json` at the bundle root, with reel support
 assets under `assets/poster/`, `assets/media/`, `assets/slides/`,
-`assets/blog/`, and `assets/downloads/`.
+`assets/blog/`, plus `assets/meta/reel_downloads.json`; only materialized mode
+adds `assets/downloads/`.
 
 If the helper reports a blocked stage, stop and complete that named full skill
 stage. Do not write a simplified poster, video, blog outline, slide image, or

--- a/ResearchStudio-Reel/skills/paper2reel/assets/section_modal_contract.json
+++ b/ResearchStudio-Reel/skills/paper2reel/assets/section_modal_contract.json
@@ -29,6 +29,7 @@
     "double-click tooltip": "Double Click to Open",
     "local-open poster embed": "const POSTER_HTML =",
     "local-open runtime switch": "shouldUseLocalOpenRuntime",
+    "local-open on-demand guard": "onDemand && window.location.protocol === 'file:'",
     "template version marker": "attention_golden_section_modal.v1"
   },
   "forbidden_html_markers": {
@@ -54,10 +55,7 @@
     "assets/ui/reel-wordmark.png",
     "assets/slides",
     "assets/blog/figures",
-    "assets/downloads/all_final.zip",
-    "assets/downloads/poster_final.zip",
-    "assets/downloads/video_final.zip",
-    "assets/downloads/blog_final.zip"
+    "assets/meta/reel_downloads.json"
   ],
   "required_media_subdirs": [
     "assets/media/clips",
@@ -65,5 +63,7 @@
     "assets/media/slide_clips"
   ],
   "min_blog_text_chars": 80,
-  "min_download_buttons": 4
+  "min_download_buttons": 4,
+  "download_schema_version": "paper2reel.downloads.v1",
+  "download_deliveries": ["materialized", "on_demand"]
 }

--- a/ResearchStudio-Reel/skills/paper2reel/scripts/build_poster_slides_view.py
+++ b/ResearchStudio-Reel/skills/paper2reel/scripts/build_poster_slides_view.py
@@ -29,6 +29,7 @@ LOCAL_OPEN_RUNTIME = "srcdoc-poster.v1"
 MATHJAX_VERSION = "3.2.2"
 MATHJAX_TARBALL_URL = f"https://registry.npmjs.org/mathjax/-/mathjax-{MATHJAX_VERSION}.tgz"
 REEL_ROOT = Path(__file__).resolve().parents[3]
+KATEX_ASSET_DIR = REEL_ROOT / "skills" / "paper2poster" / "assets" / "katex"
 
 POSTER_DIR = "assets/poster"
 SLIDES_DIR = "assets/slides"
@@ -36,12 +37,58 @@ BLOG_FIGURES_DIR = "assets/blog/figures"
 DOWNLOADS_DIR = "assets/downloads"
 UI_DIR = "assets/ui"
 REEL_WORDMARK_SRC = REEL_ROOT / "docs" / "figures" / "reel-wordmark.png"
+DOWNLOAD_MODULE_FILES: dict[str, dict[str, set[str]]] = {
+    "poster": {
+        "files": {"poster.html", "poster.png", "poster.pdf", "poster.pptx"},
+        "directories": {
+            "assets/_pptx_build",
+            "assets/figures",
+            "assets/fonts",
+            "assets/logos",
+            "assets/qr",
+        },
+    },
+    "video": {
+        "files": {"video.mp4", "video.pptx"},
+        "directories": {"assets/captions"},
+    },
+    "blog": {
+        "files": {"blog_en.docx", "blog_zh.docx"},
+        "directories": set(),
+    },
+}
+DOWNLOAD_MODULE_ARCHIVES = {
+    "poster": "poster_final.zip",
+    "video": "video_final.zip",
+    "blog": "blog_final.zip",
+}
 
 MATHJAX_CDN_RE = re.compile(
     r"""(?P<prefix>\bsrc\s*=\s*)(?P<quote>["'])"""
     r"""(?P<url>https?://(?:cdn\.jsdelivr\.net/npm|unpkg\.com)/mathjax@[^"']*/es5/tex-svg\.js)"""
     r"""(?P=quote)""",
     re.IGNORECASE,
+)
+KATEX_CDN_REPLACEMENTS = (
+    (
+        re.compile(
+            r"https://cdn\.jsdelivr\.net/npm/katex@[^/\"']+/dist/katex\.min\.css"
+        ),
+        "katex/katex.min.css",
+    ),
+    (
+        re.compile(
+            r"https://cdn\.jsdelivr\.net/npm/katex@[^/\"']+/dist/katex\.min\.js"
+        ),
+        "katex/katex.min.js",
+    ),
+    (
+        re.compile(
+            r"https://cdn\.jsdelivr\.net/npm/katex@[^/\"']+/"
+            r"dist/contrib/auto-render\.min\.js"
+        ),
+        "katex/auto-render.min.js",
+    ),
 )
 
 
@@ -778,11 +825,15 @@ def copy_if_exists(src: Path, dst: Path) -> None:
         shutil.copy2(src, dst)
 
 
+def is_backup_artifact_name(name: str) -> bool:
+    lowered = name.lower()
+    return lowered.endswith((".bak", ".backup")) or ".bak." in lowered
+
+
 def ignore_backup_artifacts(_dir: str, names: list[str]) -> set[str]:
     ignored: set[str] = set()
     for name in names:
-        lowered = name.lower()
-        if name == "_debug" or lowered.endswith((".bak", ".backup")) or ".bak." in lowered:
+        if name == "_debug" or is_backup_artifact_name(name):
             ignored.add(name)
     return ignored
 
@@ -869,6 +920,26 @@ def install_local_mathjax_if_needed(poster_html: str, poster_out: Path, cache_di
     return rewritten, count
 
 
+def install_local_katex_if_needed(poster_html: str, poster_out: Path) -> tuple[str, int]:
+    rewritten = poster_html
+    count = 0
+    for pattern, replacement in KATEX_CDN_REPLACEMENTS:
+        rewritten, replaced = pattern.subn(replacement, rewritten)
+        count += replaced
+    if count == 0:
+        return poster_html, 0
+    if not KATEX_ASSET_DIR.is_dir():
+        raise SystemExit(
+            "poster.html references CDN KaTeX, but paper2poster's local KaTeX "
+            f"assets are missing: {KATEX_ASSET_DIR}"
+        )
+    target = poster_out / "katex"
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(KATEX_ASSET_DIR, target, ignore=ignore_backup_artifacts)
+    return rewritten, count
+
+
 def inject_srcdoc_base(poster_html: str) -> str:
     head = poster_html.split("</head>", 1)[0]
     if re.search(r"<base\s", head, flags=re.IGNORECASE):
@@ -887,9 +958,13 @@ def inject_srcdoc_base(poster_html: str) -> str:
 
 def prepare_poster_for_local_open(poster_html: Path, cache_dir: Path) -> str:
     text = poster_html.read_text(encoding="utf-8")
+    text, katex_count = install_local_katex_if_needed(text, poster_html.parent)
     text, mathjax_count = install_local_mathjax_if_needed(text, poster_html.parent, cache_dir)
-    if mathjax_count:
+    if katex_count or mathjax_count:
         poster_html.write_text(text, encoding="utf-8")
+    if katex_count:
+        print(f"[paper2reel] localized {katex_count} KaTeX reference(s) for local-open")
+    if mathjax_count:
         print(f"[paper2reel] localized {mathjax_count} MathJax reference(s) for local-open")
     return inject_srcdoc_base(text)
 
@@ -1025,7 +1100,7 @@ def copy_blog_assets(outdir: Path, blog_figures_dir: Path | None) -> dict[str, s
     blog_out.mkdir(parents=True, exist_ok=True)
     mapping: dict[str, str] = {}
     for src in sorted(blog_figures_dir.iterdir()):
-        if not src.is_file():
+        if not src.is_file() or is_backup_artifact_name(src.name):
             continue
         dst = blog_out / src.name
         shutil.copy2(src, dst)
@@ -1293,40 +1368,55 @@ def infer_slide_map(slides: list[dict[str, Any]], sections: list[dict[str, str]]
     return {sid: sorted(set(indexes)) for sid, indexes in out.items()}
 
 
-def zip_directory(src_dir: Path, zip_path: Path) -> str | None:
-    if not src_dir.is_dir():
-        return None
-    zip_path.parent.mkdir(parents=True, exist_ok=True)
-    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-        for path in sorted(src_dir.rglob("*")):
-            if path.is_file():
-                zf.write(path, path.relative_to(src_dir))
-    return zip_path.as_posix()
+def is_internal_download_path(relative: Path) -> bool:
+    return bool(
+        not relative.parts
+        or relative.parts[0] == ".claude"
+        or relative.parts[:2] == ("assets", "downloads")
+        or is_backup_artifact_name(relative.name)
+    )
 
 
-def build_all_download(
+def matches_download_module(relative: Path, module: str) -> bool:
+    spec = DOWNLOAD_MODULE_FILES[module]
+    relative_posix = relative.as_posix()
+    return (
+        relative_posix in spec["files"]
+        or any(
+            relative_posix.startswith(f"{directory}/")
+            for directory in spec["directories"]
+        )
+    )
+
+
+def download_archive_files(
+    source: Path,
     *,
-    outdir: Path,
-    poster_final_dir: Path | None,
-    blog_final_dir: Path | None,
-    video_final_dir: Path | None,
-) -> dict[str, str] | None:
-    sources = [
-        ("poster", poster_final_dir),
-        ("blog", blog_final_dir),
-        ("video", video_final_dir),
-    ]
-    available = [(name, src) for name, src in sources if src is not None and src.is_dir()]
-    if not available:
-        return None
-    zip_path = outdir / DOWNLOADS_DIR / "all_final.zip"
-    zip_path.parent.mkdir(parents=True, exist_ok=True)
-    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-        for label, src_dir in available:
-            for path in sorted(src_dir.rglob("*")):
-                if path.is_file():
-                    zf.write(path, Path(label) / path.relative_to(src_dir))
-    return {"label": "All", "href": rel_to(zip_path, outdir)}
+    module: str | None = None,
+) -> list[tuple[Path, Path]]:
+    selected: list[tuple[Path, Path]] = []
+    if not source.is_dir():
+        return selected
+    for path in sorted(source.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source)
+        if is_internal_download_path(relative):
+            continue
+        if module is not None and not matches_download_module(relative, module):
+            continue
+        selected.append((path, relative))
+    return selected
+
+
+def write_download_zip(files: list[tuple[Path, Path]], destination: Path) -> bool:
+    if not files:
+        return False
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path, archive_name in files:
+            archive.write(path, archive_name.as_posix())
+    return True
 
 
 def build_downloads(
@@ -1336,27 +1426,61 @@ def build_downloads(
     blog_final_dir: Path | None,
     video_final_dir: Path | None,
 ) -> list[dict[str, str]]:
+    """Build separate module ZIPs and one deduplicated combined archive."""
+    outdir = Path(outdir)
+    sources = {
+        "poster": Path(poster_final_dir).resolve() if poster_final_dir else None,
+        "video": Path(video_final_dir).resolve() if video_final_dir else None,
+        "blog": Path(blog_final_dir).resolve() if blog_final_dir else None,
+    }
+    available = {
+        module: source
+        for module, source in sources.items()
+        if source is not None and source.is_dir()
+    }
+    downloads_dir = outdir / DOWNLOADS_DIR
     downloads: list[dict[str, str]] = []
-    all_download = build_all_download(
-        outdir=outdir,
-        poster_final_dir=poster_final_dir,
-        blog_final_dir=blog_final_dir,
-        video_final_dir=video_final_dir,
-    )
-    if all_download:
-        downloads.append(all_download)
-    specs = [
-        ("Poster", poster_final_dir, "poster_final.zip"),
-        ("Video", video_final_dir, "video_final.zip"),
-        ("Blog", blog_final_dir, "blog_final.zip"),
-    ]
-    for label, src, filename in specs:
-        if src is None:
+    if available:
+        resolved_sources = set(available.values())
+        all_files: list[tuple[Path, Path]]
+        if len(resolved_sources) == 1:
+            source = next(iter(resolved_sources))
+            union: dict[str, tuple[Path, Path]] = {}
+            for module in available:
+                for path, relative in download_archive_files(source, module=module):
+                    union[relative.as_posix()] = (path, relative)
+            all_files = list(union.values())
+        else:
+            all_files = []
+            for module, source in available.items():
+                all_files.extend(
+                    (path, Path(module) / relative)
+                    for path, relative in download_archive_files(source)
+                )
+        all_path = downloads_dir / "all_final.zip"
+        if write_download_zip(all_files, all_path):
+            downloads.append({
+                "label": "All",
+                "href": rel_to(all_path, outdir),
+            })
+
+    source_counts: dict[Path, int] = {}
+    for source in available.values():
+        source_counts[source] = source_counts.get(source, 0) + 1
+    for module, label in (("poster", "Poster"), ("video", "Video"), ("blog", "Blog")):
+        source = available.get(module)
+        if source is None:
             continue
-        zip_path = outdir / DOWNLOADS_DIR / filename
-        written = zip_directory(src, zip_path)
-        if written:
-            downloads.append({"label": label, "href": rel_to(zip_path, outdir)})
+        shared = source_counts[source] > 1
+        archive_path = downloads_dir / DOWNLOAD_MODULE_ARCHIVES[module]
+        if write_download_zip(
+            download_archive_files(source, module=module if shared else None),
+            archive_path,
+        ):
+            downloads.append({
+                "label": label,
+                "href": rel_to(archive_path, outdir),
+            })
     return downloads
 
 

--- a/ResearchStudio-Reel/skills/paper2reel/scripts/build_poster_slides_view.py
+++ b/ResearchStudio-Reel/skills/paper2reel/scripts/build_poster_slides_view.py
@@ -20,6 +20,16 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from reel_downloads import (
+    ARCHIVE_META,
+    DOWNLOAD_MANIFEST_PATH,
+    archive_links,
+    build_download_manifest,
+    selected_files,
+    validate_download_manifest,
+    write_download_manifest,
+)
+
 
 SCHEMA_VERSION = "paper2any_alignment.v1"
 VIEWER_VERSION = "section_modal.v2"
@@ -37,32 +47,6 @@ BLOG_FIGURES_DIR = "assets/blog/figures"
 DOWNLOADS_DIR = "assets/downloads"
 UI_DIR = "assets/ui"
 REEL_WORDMARK_SRC = REEL_ROOT / "docs" / "figures" / "reel-wordmark.png"
-DOWNLOAD_MODULE_FILES: dict[str, dict[str, set[str]]] = {
-    "poster": {
-        "files": {"poster.html", "poster.png", "poster.pdf", "poster.pptx"},
-        "directories": {
-            "assets/_pptx_build",
-            "assets/figures",
-            "assets/fonts",
-            "assets/logos",
-            "assets/qr",
-        },
-    },
-    "video": {
-        "files": {"video.mp4", "video.pptx"},
-        "directories": {"assets/captions"},
-    },
-    "blog": {
-        "files": {"blog_en.docx", "blog_zh.docx"},
-        "directories": set(),
-    },
-}
-DOWNLOAD_MODULE_ARCHIVES = {
-    "poster": "poster_final.zip",
-    "video": "video_final.zip",
-    "blog": "blog_final.zip",
-}
-
 MATHJAX_CDN_RE = re.compile(
     r"""(?P<prefix>\bsrc\s*=\s*)(?P<quote>["'])"""
     r"""(?P<url>https?://(?:cdn\.jsdelivr\.net/npm|unpkg\.com)/mathjax@[^"']*/es5/tex-svg\.js)"""
@@ -448,6 +432,15 @@ function renderRail() {
 function renderDownloads() {
   const box = document.getElementById('downloadLinks');
   const downloads = ALIGNMENT.downloads || [];
+  const onDemand = ALIGNMENT.download_delivery === 'on_demand';
+  if (onDemand && window.location.protocol === 'file:') {
+    box.innerHTML = '';
+    box.style.display = 'none';
+    box.setAttribute('aria-hidden', 'true');
+    return;
+  }
+  box.style.display = '';
+  box.removeAttribute('aria-hidden');
   const icon = '<span class="download-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3v11"></path><path d="m7 10 5 5 5-5"></path><path d="M5 20h14"></path></svg></span>';
   const links = downloads.map((item, idx) => `${idx ? '<span class="download-sep" aria-hidden="true">|</span>' : ''}<a class="download-link" href="${escapeHtml(item.href)}" download>${escapeHtml(item.label)}</a>`).join('');
   box.innerHTML = icon + links;
@@ -1368,47 +1361,6 @@ def infer_slide_map(slides: list[dict[str, Any]], sections: list[dict[str, str]]
     return {sid: sorted(set(indexes)) for sid, indexes in out.items()}
 
 
-def is_internal_download_path(relative: Path) -> bool:
-    return bool(
-        not relative.parts
-        or relative.parts[0] == ".claude"
-        or relative.parts[:2] == ("assets", "downloads")
-        or is_backup_artifact_name(relative.name)
-    )
-
-
-def matches_download_module(relative: Path, module: str) -> bool:
-    spec = DOWNLOAD_MODULE_FILES[module]
-    relative_posix = relative.as_posix()
-    return (
-        relative_posix in spec["files"]
-        or any(
-            relative_posix.startswith(f"{directory}/")
-            for directory in spec["directories"]
-        )
-    )
-
-
-def download_archive_files(
-    source: Path,
-    *,
-    module: str | None = None,
-) -> list[tuple[Path, Path]]:
-    selected: list[tuple[Path, Path]] = []
-    if not source.is_dir():
-        return selected
-    for path in sorted(source.rglob("*")):
-        if not path.is_file():
-            continue
-        relative = path.relative_to(source)
-        if is_internal_download_path(relative):
-            continue
-        if module is not None and not matches_download_module(relative, module):
-            continue
-        selected.append((path, relative))
-    return selected
-
-
 def write_download_zip(files: list[tuple[Path, Path]], destination: Path) -> bool:
     if not files:
         return False
@@ -1425,8 +1377,9 @@ def build_downloads(
     poster_final_dir: Path | None,
     blog_final_dir: Path | None,
     video_final_dir: Path | None,
+    download_mode: str = "materialized",
 ) -> list[dict[str, str]]:
-    """Build separate module ZIPs and one deduplicated combined archive."""
+    """Build legacy ZIPs or an on-demand manifest, plus fixed viewer links."""
     outdir = Path(outdir)
     sources = {
         "poster": Path(poster_final_dir).resolve() if poster_final_dir else None,
@@ -1438,16 +1391,41 @@ def build_downloads(
         for module, source in sources.items()
         if source is not None and source.is_dir()
     }
+    resolved_sources = set(available.values())
+    manifest_root = next(iter(resolved_sources)) if len(resolved_sources) == 1 else outdir.resolve()
+    download_manifest = build_download_manifest(
+        bundle_root=manifest_root,
+        poster_source=available.get("poster"),
+        video_source=available.get("video"),
+        blog_source=available.get("blog"),
+        delivery=download_mode,
+    )
+    if download_mode == "on_demand":
+        issues = validate_download_manifest(
+            download_manifest,
+            bundle_root=manifest_root,
+            require_sources=True,
+        )
+        if issues:
+            first = issues[0]
+            raise SystemExit(
+                f"Cannot build on-demand Reel downloads: {first['code']}: {first['message']}"
+            )
+        downloads_dir = outdir / DOWNLOADS_DIR
+        if downloads_dir.exists():
+            shutil.rmtree(downloads_dir)
+        write_download_manifest(outdir / DOWNLOAD_MANIFEST_PATH, download_manifest)
+        return archive_links(download_mode)
+
     downloads_dir = outdir / DOWNLOADS_DIR
     downloads: list[dict[str, str]] = []
     if available:
-        resolved_sources = set(available.values())
         all_files: list[tuple[Path, Path]]
         if len(resolved_sources) == 1:
             source = next(iter(resolved_sources))
             union: dict[str, tuple[Path, Path]] = {}
             for module in available:
-                for path, relative in download_archive_files(source, module=module):
+                for path, relative in selected_files(source, module=module):
                     union[relative.as_posix()] = (path, relative)
             all_files = list(union.values())
         else:
@@ -1455,32 +1433,33 @@ def build_downloads(
             for module, source in available.items():
                 all_files.extend(
                     (path, Path(module) / relative)
-                    for path, relative in download_archive_files(source)
+                    for path, relative in selected_files(source, module=None)
                 )
-        all_path = downloads_dir / "all_final.zip"
+        all_path = downloads_dir / ARCHIVE_META["all"]["filename"]
         if write_download_zip(all_files, all_path):
             downloads.append({
-                "label": "All",
+                "label": ARCHIVE_META["all"]["label"],
                 "href": rel_to(all_path, outdir),
             })
 
     source_counts: dict[Path, int] = {}
     for source in available.values():
         source_counts[source] = source_counts.get(source, 0) + 1
-    for module, label in (("poster", "Poster"), ("video", "Video"), ("blog", "Blog")):
+    for module in ("poster", "video", "blog"):
         source = available.get(module)
         if source is None:
             continue
         shared = source_counts[source] > 1
-        archive_path = downloads_dir / DOWNLOAD_MODULE_ARCHIVES[module]
+        archive_path = downloads_dir / ARCHIVE_META[module]["filename"]
         if write_download_zip(
-            download_archive_files(source, module=module if shared else None),
+            selected_files(source, module=module if shared else None),
             archive_path,
         ):
             downloads.append({
-                "label": label,
+                "label": ARCHIVE_META[module]["label"],
                 "href": rel_to(archive_path, outdir),
             })
+    write_download_manifest(outdir / DOWNLOAD_MANIFEST_PATH, download_manifest)
     return downloads
 
 
@@ -1492,6 +1471,7 @@ def build_alignment(
     override_map: dict[str, list[int]],
     blog_outlines: dict[str, dict[str, Any] | None],
     downloads: list[dict[str, str]],
+    download_delivery: str,
 ) -> dict[str, Any]:
     sections = section_docs(poster_dir)
     auto_map = infer_slide_map(slides, sections)
@@ -1542,6 +1522,7 @@ def build_alignment(
             "poster": f"{POSTER_DIR}/poster.html",
             "slides_dir": SLIDES_DIR,
         },
+        "download_delivery": download_delivery,
         "downloads": downloads,
         "slides": [
             {
@@ -1558,6 +1539,18 @@ def build_alignment(
 
 
 def build_manifest(alignment: dict[str, Any]) -> dict[str, Any]:
+    files = {
+        "reel": "reel.html",
+        "content_alignment": "content_alignment.json",
+        "poster_dir": POSTER_DIR,
+        "slides_dir": SLIDES_DIR,
+        "blog_figures_dir": BLOG_FIGURES_DIR,
+        "media_dir": "assets/media",
+        "downloads_manifest": DOWNLOAD_MANIFEST_PATH.as_posix(),
+        "ui_dir": UI_DIR,
+    }
+    if alignment.get("download_delivery") == "materialized":
+        files["downloads_dir"] = DOWNLOADS_DIR
     return {
         "schema_version": "paper2reel.v1",
         "layout": LAYOUT_VERSION,
@@ -1569,16 +1562,7 @@ def build_manifest(alignment: dict[str, Any]) -> dict[str, Any]:
             "requires_bundle_folder": True,
             "poster_runtime": "iframe.srcdoc under file:; iframe.src under http:",
         },
-        "files": {
-            "reel": "reel.html",
-            "content_alignment": "content_alignment.json",
-            "poster_dir": POSTER_DIR,
-            "slides_dir": SLIDES_DIR,
-            "blog_figures_dir": BLOG_FIGURES_DIR,
-            "media_dir": "assets/media",
-            "downloads_dir": DOWNLOADS_DIR,
-            "ui_dir": UI_DIR,
-        },
+        "files": files,
         "counts": {
             "sections": len(alignment.get("sections") or []),
             "slides": len(alignment.get("slides") or []),
@@ -1609,6 +1593,15 @@ def parse_args() -> argparse.Namespace:
                     help="Optional paper2blog bundle directory to zip for the top menu download")
     ap.add_argument("--download-video-dir", type=Path,
                     help="Optional paper2video bundle directory to zip for the top menu download")
+    ap.add_argument(
+        "--download-mode",
+        choices=("materialized", "on_demand"),
+        default="materialized",
+        help=(
+            "materialized writes the legacy ZIPs; on_demand writes only "
+            "assets/meta/reel_downloads.json for a dynamic endpoint"
+        ),
+    )
     ap.add_argument("--outdir", required=True, type=Path,
                     help="Output reel bundle directory")
     ap.add_argument("--mathjax-cache", type=Path, default=default_mathjax_cache_dir(),
@@ -1646,6 +1639,7 @@ def main() -> int:
         poster_final_dir=download_poster_dir,
         blog_final_dir=download_blog_dir,
         video_final_dir=download_video_dir,
+        download_mode=args.download_mode,
     )
     alignment = build_alignment(
         poster_dir=poster_dir,
@@ -1657,6 +1651,7 @@ def main() -> int:
             "zh": load_blog_outline(blog_outline_zh, blog_asset_map),
         },
         downloads=downloads,
+        download_delivery=args.download_mode,
     )
     write_json(outdir / "content_alignment.json", alignment)
     write_json(outdir / "manifest.json", build_manifest(alignment))

--- a/ResearchStudio-Reel/skills/paper2reel/scripts/build_reel_from_paper.py
+++ b/ResearchStudio-Reel/skills/paper2reel/scripts/build_reel_from_paper.py
@@ -20,6 +20,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from reel_downloads import (
+    DOWNLOAD_MANIFEST_PATH,
+    build_download_manifest,
+    validate_download_manifest,
+    write_download_manifest,
+)
+
 
 STATUS_PASS = "PASS"
 STATUS_MISSING = "MISSING"
@@ -296,7 +303,13 @@ def refresh_assets(bundle_dir: Path, source_pdf: Path, python_exe: str, *, dry_r
     run_cmd(cmd, dry_run=dry_run)
 
 
-def build_viewer_command(bundle_dir: Path, staging_dir: Path, slides_dir: Path, python_exe: str) -> list[str]:
+def build_viewer_command(
+    bundle_dir: Path,
+    staging_dir: Path,
+    slides_dir: Path,
+    python_exe: str,
+    download_mode: str = "materialized",
+) -> list[str]:
     cmd = [
         python_exe,
         str(BUILD_VIEWER),
@@ -306,6 +319,8 @@ def build_viewer_command(bundle_dir: Path, staging_dir: Path, slides_dir: Path, 
         str(slides_dir),
         "--outdir",
         str(staging_dir),
+        "--download-mode",
+        download_mode,
     ]
     optional_pairs = [
         ("--script-json", bundle_dir / "assets" / "audio" / "script.json"),
@@ -369,7 +384,12 @@ def copytree_replace(src: Path, dst: Path) -> None:
         shutil.copytree(src, dst)
 
 
-def sync_reel_into_bundle(staging_dir: Path, target_dir: Path) -> None:
+def sync_reel_into_bundle(
+    staging_dir: Path,
+    target_dir: Path,
+    *,
+    download_mode: str = "materialized",
+) -> None:
     target_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(staging_dir / "reel.html", target_dir / "reel.html")
     shutil.copy2(staging_dir / "content_alignment.json", target_dir / "content_alignment.json")
@@ -378,8 +398,14 @@ def sync_reel_into_bundle(staging_dir: Path, target_dir: Path) -> None:
     target_assets = target_dir / "assets"
     target_assets.mkdir(parents=True, exist_ok=True)
 
-    for name in ("poster", "media", "blog", "downloads", "ui"):
+    for name in ("poster", "media", "blog", "ui"):
         copytree_replace(stage_assets / name, target_assets / name)
+    target_downloads = target_assets / "downloads"
+    if download_mode == "materialized":
+        copytree_replace(stage_assets / "downloads", target_downloads)
+    elif target_downloads.exists():
+        # Reclaim historical ZIPs when publishing an on-demand Reel.
+        shutil.rmtree(target_downloads)
 
     stage_slides = stage_assets / "slides"
     target_slides = target_assets / "slides"
@@ -393,6 +419,31 @@ def sync_reel_into_bundle(staging_dir: Path, target_dir: Path) -> None:
     meta_dir = target_assets / "meta"
     meta_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(staging_dir / "manifest.json", meta_dir / "reel_manifest.json")
+    if download_mode == "materialized":
+        shutil.copy2(
+            staging_dir / DOWNLOAD_MANIFEST_PATH,
+            target_dir / DOWNLOAD_MANIFEST_PATH,
+        )
+    else:
+        download_manifest = build_download_manifest(
+            bundle_root=target_dir,
+            poster_source=target_dir,
+            video_source=target_dir,
+            blog_source=target_dir,
+            delivery="on_demand",
+        )
+        issues = validate_download_manifest(
+            download_manifest,
+            bundle_root=target_dir,
+            require_sources=True,
+        )
+        if issues:
+            first = issues[0]
+            raise SystemExit(
+                "Cannot publish on-demand Reel downloads: "
+                f"{first['code']}: {first['message']}"
+            )
+        write_download_manifest(target_dir / DOWNLOAD_MANIFEST_PATH, download_manifest)
 
     manifest_path = target_dir / "manifest.json"
     manifest = load_json(manifest_path, {})
@@ -409,9 +460,11 @@ def sync_reel_into_bundle(staging_dir: Path, target_dir: Path) -> None:
             "media_dir": "assets/media",
             "slides_dir": "assets/slides",
             "blog_dir": "assets/blog",
-            "downloads_dir": "assets/downloads",
+            "downloads_manifest": DOWNLOAD_MANIFEST_PATH.as_posix(),
             "ui_dir": "assets/ui",
         }
+        if download_mode == "materialized":
+            files["reel"]["downloads_dir"] = "assets/downloads"
     reel_manifest = load_json(staging_dir / "manifest.json", {})
     if isinstance(reel_manifest, dict) and isinstance(reel_manifest.get("local_open"), dict):
         manifest["reel_local_open"] = reel_manifest["local_open"]
@@ -429,6 +482,7 @@ def build_reel(
     section_tail_seconds: float,
     keep_staging: bool,
     ffmpeg: str,
+    download_mode: str = "materialized",
 ) -> None:
     slides_dir = resolve_slides_dir(bundle_dir)
     if slides_dir is None:
@@ -441,7 +495,16 @@ def build_reel(
 
     with tempfile.TemporaryDirectory(prefix="paper2reel-build-") as tmp:
         staging_dir = Path(tmp) / "reel"
-        run_cmd(build_viewer_command(bundle_dir, staging_dir, slides_dir, python_exe), dry_run=dry_run)
+        run_cmd(
+            build_viewer_command(
+                bundle_dir,
+                staging_dir,
+                slides_dir,
+                python_exe,
+                download_mode,
+            ),
+            dry_run=dry_run,
+        )
         run_cmd(
             build_media_command(
                 bundle_dir,
@@ -454,7 +517,11 @@ def build_reel(
         )
         if dry_run:
             return
-        sync_reel_into_bundle(staging_dir, target_dir)
+        sync_reel_into_bundle(
+            staging_dir,
+            target_dir,
+            download_mode=download_mode,
+        )
         if keep_staging:
             keep_dir = target_dir / "assets" / "meta" / "reel_build_staging"
             copytree_replace(staging_dir, keep_dir)
@@ -511,6 +578,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--section-tail-seconds", type=float, default=0.9)
     parser.add_argument("--ffmpeg", default="ffmpeg", help="ffmpeg executable for timeline-backed section media.")
     parser.add_argument("--keep-staging", action="store_true", help="Copy the temporary reel staging bundle into assets/meta for debugging.")
+    parser.add_argument(
+        "--download-mode",
+        choices=("materialized", "on_demand"),
+        default="materialized",
+        help=(
+            "materialized keeps standalone ZIP downloads; on_demand publishes "
+            "only the validated download manifest for the dynamic endpoint"
+        ),
+    )
     parser.add_argument("--python", default=sys.executable, help="Python interpreter for child scripts.")
     return parser.parse_args()
 
@@ -560,6 +636,7 @@ def main() -> int:
             section_tail_seconds=args.section_tail_seconds,
             keep_staging=args.keep_staging,
             ffmpeg=args.ffmpeg,
+            download_mode=args.download_mode,
         )
         statuses = collect_statuses(bundle_dir, source_pdf, args.python, reel_dir=target_dir)
         for status in statuses:

--- a/ResearchStudio-Reel/skills/paper2reel/scripts/check_reel_package.py
+++ b/ResearchStudio-Reel/skills/paper2reel/scripts/check_reel_package.py
@@ -10,14 +10,16 @@ from __future__ import annotations
 
 import argparse
 import functools
+import hashlib
 import json
 import re
 import sys
 import threading
 import urllib.error
 import urllib.request
+import zipfile
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 
@@ -29,6 +31,31 @@ if str(SCRIPT_DIR) not in sys.path:
 from serve_reel import RangeRequestHandler, ThreadedRangeHTTPServer  # noqa: E402
 
 DEFAULT_CONTRACT_PATH = SKILL_DIR / "assets" / "section_modal_contract.json"
+DOWNLOAD_ARCHIVES = {
+    "poster": "poster_final.zip",
+    "video": "video_final.zip",
+    "blog": "blog_final.zip",
+    "all": "all_final.zip",
+}
+DOWNLOAD_PROHIBITED_FILES = {
+    "poster": {"video.mp4", "video.pptx", "blog_en.docx", "blog_zh.docx"},
+    "video": {
+        "poster.html",
+        "poster.png",
+        "poster.pdf",
+        "poster.pptx",
+        "blog_en.docx",
+        "blog_zh.docx",
+    },
+    "blog": {
+        "poster.html",
+        "poster.png",
+        "poster.pdf",
+        "poster.pptx",
+        "video.mp4",
+        "video.pptx",
+    },
+}
 
 
 DEFAULT_CONTRACT = {
@@ -185,6 +212,133 @@ def validate_no_backup_files(findings: list[dict[str, Any]], viewer_dir: Path) -
             )
 
 
+def is_backup_archive_name(name: str) -> bool:
+    lowered = name.lower()
+    return lowered.endswith((".bak", ".backup")) or ".bak." in lowered
+
+
+def archive_internal_names(names: list[str]) -> list[str]:
+    internal: list[str] = []
+    for name in names:
+        archive_path = PurePosixPath(name.replace("\\", "/"))
+        parts = archive_path.parts
+        contains_downloads = any(
+            parts[index:index + 2] == ("assets", "downloads")
+            for index in range(max(0, len(parts) - 1))
+        )
+        if (
+            archive_path.is_absolute()
+            or ".." in parts
+            or ".claude" in parts
+            or contains_downloads
+            or any(is_backup_archive_name(part) for part in parts)
+        ):
+            internal.append(name)
+    return internal
+
+
+def archive_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_download_archives(
+    findings: list[dict[str, Any]],
+    viewer_dir: Path,
+) -> None:
+    """Validate the four user-facing archives produced by paper2reel."""
+    downloads_dir = viewer_dir / "assets" / "downloads"
+    paths = {
+        module: downloads_dir / filename
+        for module, filename in DOWNLOAD_ARCHIVES.items()
+    }
+    names: dict[str, set[str]] = {}
+    valid_paths: dict[str, Path] = {}
+    for module, path in paths.items():
+        if not path.is_file():
+            add_finding(
+                findings,
+                "ERROR",
+                "DOWNLOAD_ARCHIVE_MISSING",
+                "A required Reel download archive is missing.",
+                path=rel(path, viewer_dir),
+                data={"module": module},
+            )
+            continue
+        try:
+            with zipfile.ZipFile(path) as archive:
+                archive_names = archive.namelist()
+                bad_file = archive.testzip()
+                if bad_file:
+                    raise zipfile.BadZipFile(f"CRC failure in {bad_file}")
+        except (OSError, zipfile.BadZipFile, RuntimeError) as exc:
+            add_finding(
+                findings,
+                "ERROR",
+                "DOWNLOAD_ARCHIVE_INVALID",
+                "A Reel download archive is unreadable or corrupt.",
+                path=rel(path, viewer_dir),
+                data={"module": module, "error": str(exc)},
+            )
+            continue
+
+        if len(archive_names) != len(set(archive_names)):
+            add_finding(
+                findings,
+                "ERROR",
+                "DOWNLOAD_ARCHIVE_DUPLICATE_PATH",
+                "A Reel download archive contains duplicate paths.",
+                path=rel(path, viewer_dir),
+                data={"module": module},
+            )
+        internal = archive_internal_names(archive_names)
+        if internal:
+            add_finding(
+                findings,
+                "ERROR",
+                "DOWNLOAD_ARCHIVE_INTERNAL_FILE",
+                "A Reel download archive contains internal, backup, or nested download files.",
+                path=rel(path, viewer_dir),
+                data={"module": module, "files": internal[:20]},
+            )
+        names[module] = set(archive_names)
+        valid_paths[module] = path
+
+    module_names = ("poster", "video", "blog")
+    if all(module in valid_paths for module in module_names):
+        hashes = [archive_sha256(valid_paths[module]) for module in module_names]
+        if len(set(hashes)) != len(hashes):
+            add_finding(
+                findings,
+                "ERROR",
+                "DOWNLOAD_MODULE_ARCHIVES_IDENTICAL",
+                "Poster, Video, and Blog archives must contain separate module deliverables.",
+                path=rel(downloads_dir, viewer_dir),
+            )
+
+    for module, forbidden in DOWNLOAD_PROHIBITED_FILES.items():
+        archive_names = names.get(module)
+        if archive_names is None:
+            continue
+        leaked = sorted(
+            name
+            for name in archive_names
+            if PurePosixPath(name).name in forbidden
+        )
+        if leaked:
+            add_finding(
+                findings,
+                "ERROR",
+                "DOWNLOAD_ARCHIVE_CROSS_MODULE_FILE",
+                "A Reel module archive contains another module's final deliverables.",
+                path=rel(paths[module], viewer_dir),
+                data={"module": module, "files": leaked[:20]},
+            )
+
+
 def validate_local_open_resources(findings: list[dict[str, Any]], poster_html: str, poster_path: Path, root: Path) -> None:
     resource_patterns = {
         "external script": r"<script\b[^>]*\bsrc\s*=\s*['\"]https?://",
@@ -251,6 +405,7 @@ def validate_static(
     html = html_path.read_text(encoding="utf-8") if html_path.is_file() else ""
     poster_html = poster_path.read_text(encoding="utf-8") if poster_path.is_file() else ""
     validate_no_backup_files(findings, viewer_dir)
+    validate_download_archives(findings, viewer_dir)
     validate_no_local_paths(findings, html, path=rel(html_path, viewer_dir))
     validate_local_open_resources(findings, poster_html, poster_path, viewer_dir)
     required_html_markers = contract.get("required_html_markers") if isinstance(contract.get("required_html_markers"), dict) else {}

--- a/ResearchStudio-Reel/skills/paper2reel/scripts/check_reel_package.py
+++ b/ResearchStudio-Reel/skills/paper2reel/scripts/check_reel_package.py
@@ -852,33 +852,6 @@ def browser_gate(viewer_dir: Path, screenshot: Path | None = None, *, contract: 
                 else:
                     frame.wait_for_selector("[data-section]", state="attached", timeout=5000)
                     frame.wait_for_selector("[data-section].paper-reel-clickable, .titlebar.paper-reel-clickable", state="attached", timeout=5000)
-                    poster_overflows = frame.evaluate(
-                        """() => Array.from(document.querySelectorAll('[data-section]'))
-                          .filter(el => !el.matches('button, a, .listen-btn, .listen-title, .listen-all'))
-                          .filter(el => {
-                            const r = el.getBoundingClientRect();
-                            return r.width > 40 && r.height > 30;
-                          })
-                          .map(el => {
-                            const r = el.getBoundingClientRect();
-                            const children = Array.from(el.querySelectorAll('*'))
-                              .filter(child => !child.matches('button, a, .listen-btn, .listen-title, .listen-all'))
-                              .map(child => child.getBoundingClientRect())
-                              .filter(cr => cr.width > 1 && cr.height > 1);
-                            const maxBottom = children.length ? Math.max(...children.map(cr => cr.bottom)) : r.bottom;
-                            const maxRight = children.length ? Math.max(...children.map(cr => cr.right)) : r.right;
-                            const minTop = children.length ? Math.min(...children.map(cr => cr.top)) : r.top;
-                            const minLeft = children.length ? Math.min(...children.map(cr => cr.left)) : r.left;
-                            return {
-                              section: el.getAttribute('data-section'),
-                              vertical: Math.max(0, maxBottom - r.bottom, r.top - minTop),
-                              horizontal: Math.max(0, maxRight - r.right, r.left - minLeft)
-                            };
-                          })
-                          .filter(item => item.vertical > 3 || item.horizontal > 3)"""
-                    )
-                    if poster_overflows:
-                        add_finding(findings, "ERROR", "POSTER_SECTION_OVERFLOW", "Poster iframe has section content extending outside its card.", data={"sections": poster_overflows})
                     sid = frame.evaluate(
                         """() => {
                           const candidates = Array.from(document.querySelectorAll('[data-section]'))

--- a/ResearchStudio-Reel/skills/paper2reel/scripts/check_reel_package.py
+++ b/ResearchStudio-Reel/skills/paper2reel/scripts/check_reel_package.py
@@ -29,6 +29,12 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 from serve_reel import RangeRequestHandler, ThreadedRangeHTTPServer  # noqa: E402
+from reel_downloads import (  # noqa: E402
+    ARCHIVE_META,
+    ARCHIVE_ORDER,
+    DOWNLOAD_MANIFEST_PATH,
+    validate_download_manifest,
+)
 
 DEFAULT_CONTRACT_PATH = SKILL_DIR / "assets" / "section_modal_contract.json"
 DOWNLOAD_ARCHIVES = {
@@ -78,6 +84,7 @@ DEFAULT_CONTRACT = {
         "double-click tooltip": "Double Click to Open",
         "local-open poster embed": "const POSTER_HTML =",
         "local-open runtime switch": "shouldUseLocalOpenRuntime",
+        "local-open on-demand guard": "onDemand && window.location.protocol === 'file:'",
     },
     "forbidden_html_markers": {
         "old poster tab": 'id="posterTab"',
@@ -88,7 +95,14 @@ DEFAULT_CONTRACT = {
     },
     "required_download_labels": ["All", "Poster", "Video", "Blog"],
     "required_poster_debug_markers": ["window.__togglePosterDebug", "body.debug", "dbg-bbox"],
-    "required_output_paths": ["reel.html", "content_alignment.json", "manifest.json", "assets/poster/poster.html", "assets/ui/reel-wordmark.png"],
+    "required_output_paths": [
+        "reel.html",
+        "content_alignment.json",
+        "manifest.json",
+        "assets/poster/poster.html",
+        "assets/ui/reel-wordmark.png",
+        "assets/meta/reel_downloads.json",
+    ],
     "required_media_subdirs": ["assets/media/clips", "assets/media/captions", "assets/media/slide_clips"],
     "min_blog_text_chars": 80,
     "min_download_buttons": 4,
@@ -339,6 +353,97 @@ def validate_download_archives(
             )
 
 
+def validate_download_contract(
+    findings: list[dict[str, Any]],
+    viewer_dir: Path,
+) -> dict[str, Any] | None:
+    """Validate the explicit delivery mode and its corresponding artifacts."""
+    manifest_path = viewer_dir / DOWNLOAD_MANIFEST_PATH
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        add_finding(
+            findings,
+            "ERROR",
+            "DOWNLOAD_MANIFEST_MISSING",
+            "assets/meta/reel_downloads.json is missing.",
+            path=rel(manifest_path, viewer_dir),
+        )
+        return None
+    except json.JSONDecodeError as exc:
+        add_finding(
+            findings,
+            "ERROR",
+            "DOWNLOAD_MANIFEST_INVALID",
+            f"Download manifest is invalid JSON: {exc}",
+            path=rel(manifest_path, viewer_dir),
+        )
+        return None
+    issues = validate_download_manifest(
+        payload,
+        bundle_root=viewer_dir,
+        require_sources=(
+            isinstance(payload, dict) and payload.get("delivery") == "on_demand"
+        ),
+    )
+    for issue in issues:
+        issue_path = str(issue.get("path") or "")
+        add_finding(
+            findings,
+            "ERROR",
+            str(issue["code"]),
+            str(issue["message"]),
+            path=(
+                f"{DOWNLOAD_MANIFEST_PATH.as_posix()}:{issue_path}"
+                if issue_path
+                else DOWNLOAD_MANIFEST_PATH.as_posix()
+            ),
+            data=issue.get("data") if isinstance(issue.get("data"), dict) else {},
+        )
+
+    if not isinstance(payload, dict):
+        return None
+    delivery = payload.get("delivery")
+    if delivery == "materialized":
+        validate_download_archives(findings, viewer_dir)
+    elif delivery == "on_demand":
+        downloads_dir = viewer_dir / "assets" / "downloads"
+        stale_archives = (
+            sorted(
+                path
+                for path in downloads_dir.rglob("*")
+                if path.is_file() and path.suffix.lower() == ".zip"
+            )
+            if downloads_dir.is_dir()
+            else []
+        )
+        if stale_archives:
+            add_finding(
+                findings,
+                "ERROR",
+                "ON_DEMAND_ARCHIVE_PERSISTED",
+                "On-demand Reel bundles must not persist ZIP archives under assets/downloads.",
+                path=rel(downloads_dir, viewer_dir),
+                data={"files": [rel(path, viewer_dir) for path in stale_archives[:20]]},
+            )
+    return payload
+
+
+def download_delivery(viewer_dir: Path) -> str | None:
+    try:
+        payload = json.loads(
+            (viewer_dir.resolve() / DOWNLOAD_MANIFEST_PATH).read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError):
+        return None
+    if isinstance(payload, dict) and payload.get("delivery") in {
+        "materialized",
+        "on_demand",
+    }:
+        return str(payload["delivery"])
+    return None
+
+
 def validate_local_open_resources(findings: list[dict[str, Any]], poster_html: str, poster_path: Path, root: Path) -> None:
     resource_patterns = {
         "external script": r"<script\b[^>]*\bsrc\s*=\s*['\"]https?://",
@@ -405,7 +510,7 @@ def validate_static(
     html = html_path.read_text(encoding="utf-8") if html_path.is_file() else ""
     poster_html = poster_path.read_text(encoding="utf-8") if poster_path.is_file() else ""
     validate_no_backup_files(findings, viewer_dir)
-    validate_download_archives(findings, viewer_dir)
+    download_manifest = validate_download_contract(findings, viewer_dir)
     validate_no_local_paths(findings, html, path=rel(html_path, viewer_dir))
     validate_local_open_resources(findings, poster_html, poster_path, viewer_dir)
     required_html_markers = contract.get("required_html_markers") if isinstance(contract.get("required_html_markers"), dict) else {}
@@ -531,6 +636,23 @@ def validate_static(
     if not any((viewer_dir / "assets" / "slides").glob("slide_*.*")):
         add_finding(findings, "ERROR", "SLIDE_FRAMES_MISSING", "assets/slides/ contains no slide frames.", path="assets/slides/")
     downloads = alignment.get("downloads") if isinstance(alignment.get("downloads"), list) else []
+    delivery = (
+        str(download_manifest.get("delivery"))
+        if isinstance(download_manifest, dict)
+        else None
+    )
+    if alignment.get("download_delivery") != delivery:
+        add_finding(
+            findings,
+            "ERROR",
+            "DOWNLOAD_DELIVERY_MISMATCH",
+            "content_alignment.json and reel_downloads.json must declare the same delivery mode.",
+            path=rel(alignment_path, viewer_dir),
+            data={
+                "alignment": alignment.get("download_delivery"),
+                "manifest": delivery,
+            },
+        )
     min_downloads = int(contract.get("min_download_buttons") or 0)
     if len(downloads) < min_downloads:
         add_finding(findings, "ERROR", "DOWNLOADS_MISSING", "Top menu must expose every download bundle required by the golden viewer contract.", path=rel(alignment_path, viewer_dir), data={"count": len(downloads), "required": min_downloads})
@@ -538,12 +660,42 @@ def validate_static(
     for label in contract.get("required_download_labels") or []:
         if str(label) not in download_labels:
             add_finding(findings, "ERROR", "DOWNLOAD_LABEL_MISSING", "A required top-menu download label is missing.", path=rel(alignment_path, viewer_dir), data={"label": label, "found": sorted(download_labels)})
+    expected_hrefs = {
+        kind: (
+            f"assets/downloads/{ARCHIVE_META[kind]['filename']}"
+            if delivery == "materialized"
+            else f"__download__/{kind}"
+        )
+        for kind in ARCHIVE_ORDER
+    }
+    label_to_kind = {
+        str(ARCHIVE_META[kind]["label"]): kind
+        for kind in ARCHIVE_ORDER
+    }
     for item in downloads:
         if not isinstance(item, dict):
             continue
+        label = str(item.get("label") or "")
         href = str(item.get("href") or "")
-        if not href or not (viewer_dir / href).is_file():
-            add_finding(findings, "ERROR", "DOWNLOAD_FILE_MISSING", "Download bundle listed in content_alignment.json is missing.", path=href or rel(alignment_path, viewer_dir))
+        kind = label_to_kind.get(label)
+        expected_href = expected_hrefs.get(kind) if kind else None
+        if href != expected_href:
+            add_finding(
+                findings,
+                "ERROR",
+                "DOWNLOAD_HREF_INVALID",
+                "Download link does not match the declared delivery mode.",
+                path=href or rel(alignment_path, viewer_dir),
+                data={"label": label, "actual": href, "expected": expected_href},
+            )
+        elif delivery == "materialized" and not (viewer_dir / href).is_file():
+            add_finding(
+                findings,
+                "ERROR",
+                "DOWNLOAD_FILE_MISSING",
+                "Materialized download listed in content_alignment.json is missing.",
+                path=href,
+            )
 
     for raw_section in sections:
         if not isinstance(raw_section, dict):
@@ -646,6 +798,54 @@ def validate_range_support(base_url: str, viewer_dir: Path, findings: list[dict[
         )
 
 
+def validate_on_demand_endpoints(
+    base_url: str,
+    findings: list[dict[str, Any]],
+) -> None:
+    """Verify every dynamic link resolves without materializing its ZIP."""
+    for kind in ARCHIVE_ORDER:
+        url = f"{base_url}/__download__/{kind}"
+        request = urllib.request.Request(url, method="HEAD")
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:
+                status = int(response.status)
+                content_type = str(response.headers.get("Content-Type") or "")
+                disposition = str(response.headers.get("Content-Disposition") or "")
+        except urllib.error.HTTPError as exc:
+            status = int(exc.code)
+            content_type = str(exc.headers.get("Content-Type") or "")
+            disposition = str(exc.headers.get("Content-Disposition") or "")
+        except Exception as exc:
+            add_finding(
+                findings,
+                "ERROR",
+                "DOWNLOAD_ENDPOINT_REQUEST_FAILED",
+                "Browser QA server could not validate an on-demand download endpoint.",
+                path=f"__download__/{kind}",
+                data={"error": str(exc)},
+            )
+            continue
+        expected_filename = str(ARCHIVE_META[kind]["filename"])
+        if (
+            status != 200
+            or "application/zip" not in content_type.lower()
+            or expected_filename not in disposition
+        ):
+            add_finding(
+                findings,
+                "ERROR",
+                "DOWNLOAD_ENDPOINT_INVALID",
+                "On-demand download endpoint did not return the expected ZIP response.",
+                path=f"__download__/{kind}",
+                data={
+                    "status": status,
+                    "content_type": content_type,
+                    "content_disposition": disposition,
+                    "expected_filename": expected_filename,
+                },
+            )
+
+
 def direct_video_seek(page: Any, findings: list[dict[str, Any]], *, label: str) -> None:
     try:
         result = page.evaluate(
@@ -701,7 +901,13 @@ def direct_video_seek(page: Any, findings: list[dict[str, Any]], *, label: str) 
         )
 
 
-def validate_topbar_layout(page: Any, findings: list[dict[str, Any]], *, label: str) -> None:
+def validate_topbar_layout(
+    page: Any,
+    findings: list[dict[str, Any]],
+    *,
+    label: str,
+    downloads_expected: bool = True,
+) -> None:
     try:
         result = page.evaluate(
             """() => {
@@ -738,7 +944,10 @@ def validate_topbar_layout(page: Any, findings: list[dict[str, Any]], *, label: 
     if not isinstance(result, dict):
         add_finding(findings, "ERROR", "TOPBAR_LAYOUT_CHECK_FAILED", "Top menu layout inspection returned no data.", data={"label": label, "result": result})
         return
-    missing = [name for name in ("brand", "rail", "downloads", "help") if not result.get(name)]
+    required_elements = ["brand", "rail", "help"]
+    if downloads_expected:
+        required_elements.append("downloads")
+    missing = [name for name in required_elements if not result.get(name)]
     if missing:
         add_finding(findings, "ERROR", "TOPBAR_ELEMENT_MISSING", "Top menu is missing an element required by the current layout.", data={"label": label, "missing": missing, "result": result})
         return
@@ -753,12 +962,17 @@ def validate_topbar_layout(page: Any, findings: list[dict[str, Any]], *, label: 
     rail = result["rail"]
     downloads = result["downloads"]
     help_btn = result["help"]
-    if not (brand["left"] < rail["left"] < downloads["left"] < help_btn["left"]):
+    ordered = (
+        brand["left"] < rail["left"] < downloads["left"] < help_btn["left"]
+        if downloads_expected
+        else brand["left"] < rail["left"] < help_btn["left"]
+    )
+    if not ordered:
         add_finding(
             findings,
             "ERROR",
             "TOPBAR_LAYOUT_ORDER_WRONG",
-            "Top menu must place the Reel wordmark and editorial section tabs on the left, with downloads and Help on the right.",
+            "Top menu elements are not in the required editorial order.",
             data={"label": label, "layout": result},
         )
     try:
@@ -894,6 +1108,7 @@ def validate_browser_seek_interactions(page: Any, findings: list[dict[str, Any]]
 def browser_gate(viewer_dir: Path, screenshot: Path | None = None, *, contract: dict[str, Any] | None = None) -> list[dict[str, Any]]:
     findings: list[dict[str, Any]] = []
     contract = contract or load_contract()
+    delivery = download_delivery(viewer_dir)
     min_downloads = int(contract.get("min_download_buttons") or DEFAULT_CONTRACT["min_download_buttons"])
     min_blog_text = int(contract.get("min_blog_text_chars") or DEFAULT_CONTRACT["min_blog_text_chars"])
     try:
@@ -910,6 +1125,8 @@ def browser_gate(viewer_dir: Path, screenshot: Path | None = None, *, contract: 
         base_url = f"http://127.0.0.1:{port}"
         url = f"{base_url}/reel.html"
         validate_range_support(base_url, viewer_dir.resolve(), findings)
+        if delivery == "on_demand":
+            validate_on_demand_endpoints(base_url, findings)
         try:
             with sync_playwright() as p:
                 browser = p.chromium.launch(headless=True)
@@ -1119,6 +1336,7 @@ def file_browser_gate(viewer_dir: Path, screenshot: Path | None = None, *, contr
     """
     findings: list[dict[str, Any]] = []
     contract = contract or load_contract()
+    delivery = download_delivery(viewer_dir)
     min_downloads = int(contract.get("min_download_buttons") or DEFAULT_CONTRACT["min_download_buttons"])
     min_blog_text = int(contract.get("min_blog_text_chars") or DEFAULT_CONTRACT["min_blog_text_chars"])
     html_path = viewer_dir.resolve() / "reel.html"
@@ -1172,9 +1390,27 @@ def file_browser_gate(viewer_dir: Path, screenshot: Path | None = None, *, contr
             topbar_after_v = page.locator(".topbar").evaluate("el => getComputedStyle(el).display")
             if topbar_after_v == "none":
                 add_finding(findings, "ERROR", "MENU_SHORTCUT_BROKEN", "Shortcut v did not show the top menu in file-open mode.")
-            validate_topbar_layout(page, findings, label="file")
+            validate_topbar_layout(
+                page,
+                findings,
+                label="file",
+                downloads_expected=delivery != "on_demand",
+            )
             download_count = page.locator("#downloadLinks .download-link").count()
-            if download_count < min_downloads:
+            download_display = page.locator("#downloadLinks").evaluate(
+                "el => getComputedStyle(el).display"
+            )
+            if delivery == "on_demand" and (
+                download_count != 0 or download_display != "none"
+            ):
+                add_finding(
+                    findings,
+                    "ERROR",
+                    "FILE_ON_DEMAND_DOWNLOADS_VISIBLE",
+                    "Online-only downloads must be hidden when reel.html is opened through file://.",
+                    data={"count": download_count, "display": download_display},
+                )
+            elif delivery != "on_demand" and download_count < min_downloads:
                 add_finding(findings, "ERROR", "DOWNLOAD_BUTTONS_MISSING", "Top menu has fewer download buttons than the golden viewer contract requires in file-open mode.", data={"count": download_count, "required": min_downloads})
 
             frame = page.locator("#posterFrame").element_handle().content_frame()

--- a/ResearchStudio-Reel/skills/paper2reel/scripts/reel_downloads.py
+++ b/ResearchStudio-Reel/skills/paper2reel/scripts/reel_downloads.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Shared Paper2Reel download-manifest contract.
+
+The manifest describes the files in each user-facing archive without requiring
+an archive to be persisted in the Reel bundle.  Both the standalone server and
+the final-package checker use this module so path validation cannot drift.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+
+DOWNLOAD_SCHEMA_VERSION = "paper2reel.downloads.v1"
+DOWNLOAD_MANIFEST_PATH = Path("assets/meta/reel_downloads.json")
+DOWNLOAD_DELIVERIES = {"materialized", "on_demand"}
+ARCHIVE_ORDER = ("all", "poster", "video", "blog")
+ARCHIVE_META = {
+    "all": {"label": "All", "filename": "all_final.zip"},
+    "poster": {"label": "Poster", "filename": "poster_final.zip"},
+    "video": {"label": "Video", "filename": "video_final.zip"},
+    "blog": {"label": "Blog", "filename": "blog_final.zip"},
+}
+MODULE_FILES: dict[str, dict[str, set[str]]] = {
+    "poster": {
+        "files": {"poster.html", "poster.png", "poster.pdf", "poster.pptx"},
+        "directories": {
+            "assets/_pptx_build",
+            "assets/figures",
+            "assets/fonts",
+            "assets/logos",
+            "assets/qr",
+        },
+    },
+    "video": {
+        "files": {"video.mp4", "video.pptx"},
+        "directories": {"assets/captions"},
+    },
+    "blog": {
+        "files": {"blog_en.docx", "blog_zh.docx"},
+        "directories": set(),
+    },
+}
+PROHIBITED_PARTS = {
+    ".claude",
+    ".codex",
+    ".git",
+    "__pycache__",
+    "_debug",
+    "backup",
+    "backups",
+    "downloads",
+    "internal",
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def is_backup_name(name: str) -> bool:
+    lowered = name.lower()
+    return (
+        lowered.endswith((".bak", ".backup", ".old", ".orig", "~"))
+        or ".bak." in lowered
+        or ".backup." in lowered
+    )
+
+
+def is_safe_relative_posix(value: str) -> bool:
+    """Return whether *value* is a normalized, non-internal POSIX path."""
+    if (
+        not value
+        or value != value.strip()
+        or "\\" in value
+        or value.startswith("/")
+        or any(ord(char) < 32 or ord(char) == 127 for char in value)
+    ):
+        return False
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        return False
+    if path.as_posix() != value:
+        return False
+    lowered_parts = {part.lower() for part in path.parts}
+    if lowered_parts & PROHIBITED_PARTS:
+        return False
+    return not any(is_backup_name(part) for part in path.parts)
+
+
+def is_internal_path(relative: Path) -> bool:
+    value = relative.as_posix()
+    return not is_safe_relative_posix(value)
+
+
+def matches_module(relative: Path | PurePosixPath, module: str) -> bool:
+    spec = MODULE_FILES[module]
+    relative_posix = relative.as_posix()
+    return (
+        relative_posix in spec["files"]
+        or any(
+            relative_posix.startswith(f"{directory}/")
+            for directory in spec["directories"]
+        )
+    )
+
+
+def selected_files(
+    source: Path,
+    *,
+    module: str | None,
+) -> list[tuple[Path, Path]]:
+    """Return safe files below *source*, optionally restricted by module."""
+    selected: list[tuple[Path, Path]] = []
+    source = source.resolve()
+    if not source.is_dir():
+        return selected
+    for path in sorted(source.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source)
+        if is_internal_path(relative):
+            continue
+        if module is not None and not matches_module(relative, module):
+            continue
+        selected.append((path, relative))
+    return selected
+
+
+def _bundle_path(path: Path, source: Path, bundle_root: Path, *, strict: bool) -> str:
+    try:
+        return path.resolve().relative_to(bundle_root.resolve()).as_posix()
+    except ValueError:
+        if strict:
+            raise ValueError(
+                f"on-demand download source is outside the final bundle: {path}"
+            )
+        return path.resolve().relative_to(source.resolve()).as_posix()
+
+
+def _entry(path: Path, relative: Path, source: Path, bundle_root: Path, *, strict: bool) -> dict[str, Any]:
+    return {
+        "path": _bundle_path(path, source, bundle_root, strict=strict),
+        "arcname": relative.as_posix(),
+        "size": path.stat().st_size,
+    }
+
+
+def build_download_manifest(
+    *,
+    bundle_root: Path,
+    poster_source: Path | None,
+    video_source: Path | None,
+    blog_source: Path | None,
+    delivery: str,
+) -> dict[str, Any]:
+    """Build a deterministic download manifest from final-deliverable sources.
+
+    ``on_demand`` is intentionally strict: every selected source must live
+    below ``bundle_root`` and every module uses the explicit deliverable
+    whitelist.  ``materialized`` preserves the legacy behavior for separate
+    per-module source directories, where the whole safe source directory was
+    archived.
+    """
+    if delivery not in DOWNLOAD_DELIVERIES:
+        raise ValueError(f"unsupported download delivery mode: {delivery}")
+
+    bundle_root = bundle_root.resolve()
+    raw_sources = {
+        "poster": poster_source,
+        "video": video_source,
+        "blog": blog_source,
+    }
+    sources = {
+        module: Path(source).resolve()
+        for module, source in raw_sources.items()
+        if source is not None and Path(source).is_dir()
+    }
+    source_counts: dict[Path, int] = {}
+    for source in sources.values():
+        source_counts[source] = source_counts.get(source, 0) + 1
+
+    module_entries: dict[str, list[dict[str, Any]]] = {
+        "poster": [],
+        "video": [],
+        "blog": [],
+    }
+    strict = delivery == "on_demand"
+    for module in ("poster", "video", "blog"):
+        source = sources.get(module)
+        if source is None:
+            continue
+        shared_source = source_counts[source] > 1
+        module_filter = module if strict or shared_source else None
+        module_entries[module] = [
+            _entry(path, relative, source, bundle_root, strict=strict)
+            for path, relative in selected_files(source, module=module_filter)
+        ]
+
+    all_entries: dict[str, dict[str, Any]] = {}
+    if len(set(sources.values())) <= 1:
+        for module in ("poster", "video", "blog"):
+            for item in module_entries[module]:
+                all_entries.setdefault(str(item["arcname"]), dict(item))
+    else:
+        for module in ("poster", "video", "blog"):
+            for item in module_entries[module]:
+                combined = dict(item)
+                combined["arcname"] = f"{module}/{item['arcname']}"
+                all_entries.setdefault(str(combined["arcname"]), combined)
+
+    archives: dict[str, dict[str, Any]] = {}
+    entries_by_archive = {
+        "all": sorted(all_entries.values(), key=lambda item: str(item["arcname"])),
+        **{
+            module: sorted(module_entries[module], key=lambda item: str(item["arcname"]))
+            for module in ("poster", "video", "blog")
+        },
+    }
+    for kind in ARCHIVE_ORDER:
+        archives[kind] = {
+            **ARCHIVE_META[kind],
+            "files": entries_by_archive[kind],
+        }
+    return {
+        "schema_version": DOWNLOAD_SCHEMA_VERSION,
+        "delivery": delivery,
+        "created_at": utc_now(),
+        "archives": archives,
+    }
+
+
+def write_download_manifest(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _issue(
+    code: str,
+    message: str,
+    *,
+    path: str | None = None,
+    data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "code": code,
+        "message": message,
+        "path": path,
+        "data": data or {},
+    }
+
+
+def validate_download_manifest(
+    payload: Any,
+    *,
+    bundle_root: Path,
+    require_sources: bool | None = None,
+) -> list[dict[str, Any]]:
+    """Validate manifest schema, classification, path safety, and sources."""
+    issues: list[dict[str, Any]] = []
+    bundle_root = bundle_root.resolve()
+    if not isinstance(payload, dict):
+        return [_issue("DOWNLOAD_MANIFEST_SCHEMA_INVALID", "Download manifest must be a JSON object.")]
+    if payload.get("schema_version") != DOWNLOAD_SCHEMA_VERSION:
+        issues.append(
+            _issue(
+                "DOWNLOAD_MANIFEST_SCHEMA_INVALID",
+                f"schema_version must be {DOWNLOAD_SCHEMA_VERSION}.",
+                data={"actual": payload.get("schema_version")},
+            )
+        )
+    delivery = payload.get("delivery")
+    if delivery not in DOWNLOAD_DELIVERIES:
+        issues.append(
+            _issue(
+                "DOWNLOAD_DELIVERY_INVALID",
+                "Download manifest delivery must be materialized or on_demand.",
+                data={"actual": delivery},
+            )
+        )
+    if require_sources is None:
+        require_sources = delivery == "on_demand"
+
+    archives = payload.get("archives")
+    if not isinstance(archives, dict):
+        issues.append(_issue("DOWNLOAD_ARCHIVES_SCHEMA_INVALID", "archives must be an object."))
+        return issues
+    actual_kinds = set(archives)
+    expected_kinds = set(ARCHIVE_ORDER)
+    if actual_kinds != expected_kinds:
+        issues.append(
+            _issue(
+                "DOWNLOAD_ARCHIVE_SET_INVALID",
+                "archives must contain exactly all, poster, video, and blog.",
+                data={"actual": sorted(actual_kinds), "expected": list(ARCHIVE_ORDER)},
+            )
+        )
+
+    normalized: dict[str, list[tuple[str, str, int]]] = {}
+    for kind in ARCHIVE_ORDER:
+        archive = archives.get(kind)
+        if not isinstance(archive, dict):
+            issues.append(
+                _issue(
+                    "DOWNLOAD_ARCHIVE_SCHEMA_INVALID",
+                    "Archive entry must be an object.",
+                    path=f"archives.{kind}",
+                )
+            )
+            continue
+        expected = ARCHIVE_META[kind]
+        for field in ("label", "filename"):
+            if archive.get(field) != expected[field]:
+                issues.append(
+                    _issue(
+                        "DOWNLOAD_ARCHIVE_METADATA_INVALID",
+                        f"Archive {kind} has an invalid {field}.",
+                        path=f"archives.{kind}.{field}",
+                        data={"actual": archive.get(field), "expected": expected[field]},
+                    )
+                )
+        files = archive.get("files")
+        if not isinstance(files, list):
+            issues.append(
+                _issue(
+                    "DOWNLOAD_FILES_SCHEMA_INVALID",
+                    "Archive files must be a list.",
+                    path=f"archives.{kind}.files",
+                )
+            )
+            continue
+        if delivery == "on_demand" and not files:
+            issues.append(
+                _issue(
+                    "DOWNLOAD_ARCHIVE_EMPTY",
+                    "Every on-demand archive must contain at least one whitelisted source file.",
+                    path=f"archives.{kind}.files",
+                )
+            )
+        seen_paths: set[str] = set()
+        seen_arcnames: set[str] = set()
+        valid_entries: list[tuple[str, str, int]] = []
+        for index, item in enumerate(files):
+            item_path = f"archives.{kind}.files[{index}]"
+            if not isinstance(item, dict):
+                issues.append(
+                    _issue("DOWNLOAD_FILE_SCHEMA_INVALID", "Download file entry must be an object.", path=item_path)
+                )
+                continue
+            source_path = item.get("path")
+            arcname = item.get("arcname")
+            size = item.get("size")
+            if not isinstance(source_path, str) or not is_safe_relative_posix(source_path):
+                issues.append(
+                    _issue(
+                        "DOWNLOAD_SOURCE_PATH_UNSAFE",
+                        "Download source path must be a safe bundle-relative POSIX path.",
+                        path=f"{item_path}.path",
+                        data={"value": source_path},
+                    )
+                )
+                continue
+            if not isinstance(arcname, str) or not is_safe_relative_posix(arcname):
+                issues.append(
+                    _issue(
+                        "DOWNLOAD_ARCHIVE_PATH_UNSAFE",
+                        "Download archive name must be a safe relative POSIX path.",
+                        path=f"{item_path}.arcname",
+                        data={"value": arcname},
+                    )
+                )
+                continue
+            if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+                issues.append(
+                    _issue(
+                        "DOWNLOAD_SOURCE_SIZE_INVALID",
+                        "Download source size must be a non-negative integer.",
+                        path=f"{item_path}.size",
+                        data={"value": size},
+                    )
+                )
+                continue
+            arcname_key = arcname.casefold()
+            duplicate_source = (
+                delivery == "on_demand"
+                and source_path in seen_paths
+            )
+            if duplicate_source or arcname_key in seen_arcnames:
+                issues.append(
+                    _issue(
+                        "DOWNLOAD_FILE_DUPLICATE",
+                        "Archive files must not repeat a source path or archive name.",
+                        path=item_path,
+                        data={"path": source_path, "arcname": arcname},
+                    )
+                )
+                continue
+            seen_paths.add(source_path)
+            seen_arcnames.add(arcname_key)
+
+            if delivery == "on_demand" and kind in MODULE_FILES:
+                if not matches_module(PurePosixPath(source_path), kind) or not matches_module(
+                    PurePosixPath(arcname), kind
+                ):
+                    issues.append(
+                        _issue(
+                            "DOWNLOAD_FILE_CLASSIFICATION_INVALID",
+                            "On-demand module archives may contain only their whitelisted final deliverables.",
+                            path=item_path,
+                            data={"archive": kind, "path": source_path, "arcname": arcname},
+                        )
+                    )
+
+            if require_sources:
+                candidate = bundle_root / source_path
+                try:
+                    resolved = candidate.resolve()
+                    resolved.relative_to(bundle_root)
+                except (OSError, ValueError):
+                    issues.append(
+                        _issue(
+                            "DOWNLOAD_SOURCE_PATH_ESCAPE",
+                            "Download source resolves outside the Reel bundle.",
+                            path=source_path,
+                        )
+                    )
+                else:
+                    if not resolved.is_file():
+                        issues.append(
+                            _issue(
+                                "DOWNLOAD_SOURCE_MISSING",
+                                "Download source listed in the manifest is missing.",
+                                path=source_path,
+                                data={"archive": kind},
+                            )
+                        )
+                    elif resolved.stat().st_size != size:
+                        issues.append(
+                            _issue(
+                                "DOWNLOAD_SOURCE_SIZE_MISMATCH",
+                                "Download source size no longer matches the manifest.",
+                                path=source_path,
+                                data={
+                                    "archive": kind,
+                                    "actual": resolved.stat().st_size,
+                                    "expected": size,
+                                },
+                            )
+                        )
+            valid_entries.append((source_path, arcname, size))
+        normalized[kind] = valid_entries
+
+    if delivery == "on_demand" and all(kind in normalized for kind in ARCHIVE_ORDER):
+        expected_all: dict[str, tuple[str, str, int]] = {}
+        for kind in ("poster", "video", "blog"):
+            for entry in normalized[kind]:
+                expected_all.setdefault(entry[1].casefold(), entry)
+        actual_all = {
+            entry[1].casefold(): entry
+            for entry in normalized["all"]
+        }
+        if actual_all != expected_all:
+            issues.append(
+                _issue(
+                    "DOWNLOAD_ALL_UNION_INVALID",
+                    "The All archive must be the deduplicated union of Poster, Video, and Blog.",
+                    path="archives.all.files",
+                )
+            )
+    return issues
+
+
+def read_download_manifest(bundle_root: Path) -> dict[str, Any]:
+    manifest_path = bundle_root.resolve() / DOWNLOAD_MANIFEST_PATH
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"download manifest missing: {manifest_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"download manifest is invalid JSON: {exc}") from exc
+    issues = validate_download_manifest(payload, bundle_root=bundle_root)
+    if issues:
+        first = issues[0]
+        raise ValueError(f"{first['code']}: {first['message']}")
+    return payload
+
+
+def archive_files(
+    payload: dict[str, Any],
+    kind: str,
+    *,
+    bundle_root: Path,
+) -> tuple[str, list[tuple[Path, str]]]:
+    """Resolve one validated on-demand archive to concrete source paths."""
+    if kind not in ARCHIVE_ORDER:
+        raise ValueError(f"unknown download archive: {kind}")
+    if payload.get("delivery") != "on_demand":
+        raise ValueError("dynamic downloads require delivery=on_demand")
+    issues = validate_download_manifest(payload, bundle_root=bundle_root, require_sources=True)
+    if issues:
+        first = issues[0]
+        raise ValueError(f"{first['code']}: {first['message']}")
+    archive = payload["archives"][kind]
+    files = [
+        (bundle_root.resolve() / item["path"], item["arcname"])
+        for item in archive["files"]
+    ]
+    return str(archive["filename"]), files
+
+
+def archive_links(delivery: str) -> list[dict[str, str]]:
+    """Return fixed-order viewer links for one delivery mode."""
+    if delivery not in DOWNLOAD_DELIVERIES:
+        raise ValueError(f"unsupported download delivery mode: {delivery}")
+    return [
+        {
+            "label": ARCHIVE_META[kind]["label"],
+            "href": (
+                f"assets/downloads/{ARCHIVE_META[kind]['filename']}"
+                if delivery == "materialized"
+                else f"__download__/{kind}"
+            ),
+        }
+        for kind in ARCHIVE_ORDER
+    ]

--- a/ResearchStudio-Reel/skills/paper2reel/scripts/serve_reel.py
+++ b/ResearchStudio-Reel/skills/paper2reel/scripts/serve_reel.py
@@ -16,12 +16,17 @@ import os
 import re
 import shutil
 import socketserver
+import tempfile
 import urllib.parse
+import zipfile
 from pathlib import Path
 from typing import BinaryIO
 
+from reel_downloads import archive_files, read_download_manifest
+
 
 RANGE_RE = re.compile(r"bytes=(\d*)-(\d*)$")
+DOWNLOAD_ROUTE_RE = re.compile(r"^/__download__/(all|poster|video|blog)/?$")
 
 
 class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
@@ -36,6 +41,64 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
     def end_headers(self) -> None:
         self.send_header("Accept-Ranges", "bytes")
         super().end_headers()
+
+    def _download_kind(self) -> str | None:
+        path = urllib.parse.urlsplit(self.path).path
+        match = DOWNLOAD_ROUTE_RE.fullmatch(path)
+        return match.group(1) if match else None
+
+    def _download_spec(self, kind: str) -> tuple[str, list[tuple[Path, str]]]:
+        bundle_root = Path(self.directory).resolve()
+        manifest = read_download_manifest(bundle_root)
+        return archive_files(manifest, kind, bundle_root=bundle_root)
+
+    def _serve_download(self, kind: str, *, head_only: bool) -> None:
+        try:
+            filename, files = self._download_spec(kind)
+        except ValueError as exc:
+            self.send_error(http.HTTPStatus.CONFLICT, str(exc))
+            return
+
+        if head_only:
+            self.send_response(http.HTTPStatus.OK)
+            self.send_header("Content-Type", "application/zip")
+            self.send_header("Content-Disposition", f'attachment; filename="{filename}"')
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            return
+
+        with tempfile.SpooledTemporaryFile(max_size=8 * 1024 * 1024, mode="w+b") as stream:
+            with zipfile.ZipFile(
+                stream,
+                "w",
+                compression=zipfile.ZIP_DEFLATED,
+                allowZip64=True,
+            ) as archive:
+                for source, arcname in files:
+                    archive.write(source, arcname)
+            size = stream.tell()
+            stream.seek(0)
+            self.send_response(http.HTTPStatus.OK)
+            self.send_header("Content-Type", "application/zip")
+            self.send_header("Content-Disposition", f'attachment; filename="{filename}"')
+            self.send_header("Content-Length", str(size))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            shutil.copyfileobj(stream, self.wfile, length=64 * 1024)
+
+    def do_HEAD(self) -> None:  # noqa: N802
+        kind = self._download_kind()
+        if kind is None:
+            super().do_HEAD()
+            return
+        self._serve_download(kind, head_only=True)
+
+    def do_GET(self) -> None:  # noqa: N802
+        kind = self._download_kind()
+        if kind is None:
+            super().do_GET()
+            return
+        self._serve_download(kind, head_only=False)
 
     def _parse_range(self, header: str, size: int) -> tuple[int, int] | None:
         match = RANGE_RE.match(header.strip())

--- a/ResearchStudio-Reel/skills/paper2reel/tests/test_download_archives.py
+++ b/ResearchStudio-Reel/skills/paper2reel/tests/test_download_archives.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import functools
 import hashlib
+import io
+import json
 import sys
 import tempfile
+import threading
 import unittest
+import urllib.request
 import zipfile
 from pathlib import Path
 from unittest.mock import patch
@@ -15,7 +20,10 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 import build_poster_slides_view as builder  # noqa: E402
+import build_reel_from_paper as bootstrap  # noqa: E402
 import check_reel_package as checker  # noqa: E402
+import reel_downloads  # noqa: E402
+from serve_reel import RangeRequestHandler, ThreadedRangeHTTPServer  # noqa: E402
 
 
 def write(path: Path, contents: bytes = b"x") -> None:
@@ -37,6 +45,10 @@ def zip_names(path: Path) -> set[str]:
 
 def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 class ReelDownloadBuilderTests(unittest.TestCase):
@@ -79,6 +91,18 @@ class ReelDownloadBuilderTests(unittest.TestCase):
             self.assertEqual(
                 ["All", "Poster", "Video", "Blog"],
                 [item["label"] for item in downloads],
+            )
+            download_manifest = read_json(
+                bundle / reel_downloads.DOWNLOAD_MANIFEST_PATH
+            )
+            self.assertEqual(
+                reel_downloads.DOWNLOAD_SCHEMA_VERSION,
+                download_manifest["schema_version"],
+            )
+            self.assertEqual("materialized", download_manifest["delivery"])
+            self.assertEqual(
+                set(reel_downloads.ARCHIVE_ORDER),
+                set(download_manifest["archives"]),
             )
             archive_dir = bundle / "assets" / "downloads"
             names = {
@@ -161,6 +185,108 @@ class ReelDownloadBuilderTests(unittest.TestCase):
                 )
                 self.assertFalse(any(name.endswith(".zip") for name in archive_names))
 
+    def test_materialized_separate_sources_allow_same_relative_source_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            outdir = root / "reel"
+            poster = root / "poster"
+            video = root / "video"
+            blog = root / "blog"
+            write(poster / "poster.png", b"poster")
+            write(video / "video.mp4", b"video")
+            write(blog / "blog_en.docx", b"blog")
+            for source in (poster, video, blog):
+                write(source / "manifest.json", b"{}")
+
+            builder.build_downloads(
+                outdir=outdir,
+                poster_final_dir=poster,
+                video_final_dir=video,
+                blog_final_dir=blog,
+                download_mode="materialized",
+            )
+
+            manifest = read_json(outdir / reel_downloads.DOWNLOAD_MANIFEST_PATH)
+            self.assertEqual(
+                [],
+                reel_downloads.validate_download_manifest(
+                    manifest,
+                    bundle_root=outdir,
+                    require_sources=False,
+                ),
+            )
+            all_names = zip_names(
+                outdir / "assets" / "downloads" / "all_final.zip"
+            )
+            self.assertIn("poster/manifest.json", all_names)
+            self.assertIn("video/manifest.json", all_names)
+            self.assertIn("blog/manifest.json", all_names)
+
+    def test_on_demand_writes_manifest_without_persistent_archives(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = self.make_shared_bundle(Path(tmp))
+            downloads = builder.build_downloads(
+                outdir=bundle,
+                poster_final_dir=bundle,
+                blog_final_dir=bundle,
+                video_final_dir=bundle,
+                download_mode="on_demand",
+            )
+
+            self.assertEqual(
+                [
+                    {"label": "All", "href": "__download__/all"},
+                    {"label": "Poster", "href": "__download__/poster"},
+                    {"label": "Video", "href": "__download__/video"},
+                    {"label": "Blog", "href": "__download__/blog"},
+                ],
+                downloads,
+            )
+            self.assertFalse((bundle / "assets" / "downloads").exists())
+            manifest = read_json(bundle / reel_downloads.DOWNLOAD_MANIFEST_PATH)
+            self.assertEqual("on_demand", manifest["delivery"])
+            self.assertEqual(
+                set(reel_downloads.ARCHIVE_ORDER),
+                set(manifest["archives"]),
+            )
+
+            video_files = {
+                item["arcname"]
+                for item in manifest["archives"]["video"]["files"]
+            }
+            self.assertEqual(
+                {
+                    "video.mp4",
+                    "video.pptx",
+                    "assets/captions/video.vtt",
+                },
+                video_files,
+            )
+            poster_files = {
+                item["arcname"]
+                for item in manifest["archives"]["poster"]["files"]
+            }
+            self.assertIn("poster.html", poster_files)
+            self.assertIn("assets/figures/figure1.png", poster_files)
+            self.assertNotIn("video.mp4", poster_files)
+            all_files = manifest["archives"]["all"]["files"]
+            self.assertEqual(
+                len(all_files),
+                len({item["arcname"] for item in all_files}),
+            )
+            serialized = json.dumps(manifest)
+            self.assertNotIn(".claude", serialized)
+            self.assertNotIn("assets/downloads", serialized)
+            self.assertNotIn("figure1.png.bak", serialized)
+            self.assertEqual(
+                [],
+                reel_downloads.validate_download_manifest(
+                    manifest,
+                    bundle_root=bundle,
+                    require_sources=True,
+                ),
+            )
+
 
 class ReelDownloadCheckerTests(unittest.TestCase):
     def make_valid_archives(self, root: Path) -> Path:
@@ -192,6 +318,21 @@ class ReelDownloadCheckerTests(unittest.TestCase):
     def test_static_gate_runs_download_archive_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
+            manifest = {
+                "schema_version": reel_downloads.DOWNLOAD_SCHEMA_VERSION,
+                "delivery": "materialized",
+                "archives": {
+                    kind: {
+                        **reel_downloads.ARCHIVE_META[kind],
+                        "files": [],
+                    }
+                    for kind in reel_downloads.ARCHIVE_ORDER
+                },
+            }
+            reel_downloads.write_download_manifest(
+                root / reel_downloads.DOWNLOAD_MANIFEST_PATH,
+                manifest,
+            )
             with patch.object(checker, "validate_download_archives") as archive_gate:
                 checker.validate_static(root, contract={})
             archive_gate.assert_called_once()
@@ -246,6 +387,176 @@ class ReelDownloadCheckerTests(unittest.TestCase):
 
             codes = {finding["code"] for finding in self.findings_for(root)}
             self.assertIn("DOWNLOAD_ARCHIVE_INTERNAL_FILE", codes)
+
+
+class ReelOnDemandCheckerTests(unittest.TestCase):
+    def make_bundle(self, root: Path) -> Path:
+        bundle = ReelDownloadBuilderTests().make_shared_bundle(root)
+        builder.build_downloads(
+            outdir=bundle,
+            poster_final_dir=bundle,
+            blog_final_dir=bundle,
+            video_final_dir=bundle,
+            download_mode="on_demand",
+        )
+        return bundle
+
+    def findings_for(self, root: Path) -> list[dict]:
+        findings: list[dict] = []
+        checker.validate_download_contract(findings, root)
+        return findings
+
+    def test_valid_manifest_and_sources_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.make_bundle(Path(tmp))
+            self.assertEqual([], self.findings_for(root))
+
+    def test_stale_persistent_zip_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.make_bundle(Path(tmp))
+            write(root / "assets" / "downloads" / "old.zip", b"old")
+            codes = {finding["code"] for finding in self.findings_for(root)}
+            self.assertIn("ON_DEMAND_ARCHIVE_PERSISTED", codes)
+
+    def test_unsafe_manifest_path_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.make_bundle(Path(tmp))
+            path = root / reel_downloads.DOWNLOAD_MANIFEST_PATH
+            manifest = read_json(path)
+            manifest["archives"]["blog"]["files"][0]["path"] = "../secret"
+            reel_downloads.write_download_manifest(path, manifest)
+            codes = {finding["code"] for finding in self.findings_for(root)}
+            self.assertIn("DOWNLOAD_SOURCE_PATH_UNSAFE", codes)
+
+    def test_control_character_in_manifest_path_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.make_bundle(Path(tmp))
+            path = root / reel_downloads.DOWNLOAD_MANIFEST_PATH
+            manifest = read_json(path)
+            manifest["archives"]["blog"]["files"][0]["arcname"] += "\n"
+            reel_downloads.write_download_manifest(path, manifest)
+            codes = {finding["code"] for finding in self.findings_for(root)}
+            self.assertIn("DOWNLOAD_ARCHIVE_PATH_UNSAFE", codes)
+
+    def test_cross_module_source_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.make_bundle(Path(tmp))
+            path = root / reel_downloads.DOWNLOAD_MANIFEST_PATH
+            manifest = read_json(path)
+            leaked = dict(manifest["archives"]["video"]["files"][0])
+            manifest["archives"]["poster"]["files"].append(leaked)
+            reel_downloads.write_download_manifest(path, manifest)
+            codes = {finding["code"] for finding in self.findings_for(root)}
+            self.assertIn("DOWNLOAD_FILE_CLASSIFICATION_INVALID", codes)
+
+    def test_missing_source_and_size_drift_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.make_bundle(Path(tmp))
+            (root / "video.mp4").unlink()
+            write(root / "blog_en.docx", b"changed-size")
+            codes = {finding["code"] for finding in self.findings_for(root)}
+            self.assertIn("DOWNLOAD_SOURCE_MISSING", codes)
+            self.assertIn("DOWNLOAD_SOURCE_SIZE_MISMATCH", codes)
+
+
+class ReelOnDemandServerTests(unittest.TestCase):
+    def test_server_streams_manifest_archive_without_persisting_zip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = ReelDownloadBuilderTests().make_shared_bundle(Path(tmp))
+            builder.build_downloads(
+                outdir=root,
+                poster_final_dir=root,
+                blog_final_dir=root,
+                video_final_dir=root,
+                download_mode="on_demand",
+            )
+            handler = functools.partial(
+                RangeRequestHandler,
+                directory=str(root.resolve()),
+            )
+            try:
+                httpd = ThreadedRangeHTTPServer(("127.0.0.1", 0), handler)
+            except PermissionError:
+                self.skipTest("loopback sockets are unavailable in this sandbox")
+            with httpd:
+                thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+                thread.start()
+                port = int(httpd.server_address[1])
+                try:
+                    head = urllib.request.Request(
+                        f"http://127.0.0.1:{port}/__download__/all",
+                        method="HEAD",
+                    )
+                    with urllib.request.urlopen(head, timeout=5) as response:
+                        self.assertEqual(200, response.status)
+                        self.assertIn(
+                            "all_final.zip",
+                            response.headers["Content-Disposition"],
+                        )
+                    with urllib.request.urlopen(
+                        f"http://127.0.0.1:{port}/__download__/blog",
+                        timeout=5,
+                    ) as response:
+                        payload = response.read()
+                finally:
+                    httpd.shutdown()
+                    thread.join(timeout=2)
+
+            with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+                self.assertEqual(
+                    {"blog_en.docx", "blog_zh.docx"},
+                    set(archive.namelist()),
+                )
+            self.assertFalse((root / "assets" / "downloads").exists())
+
+
+class ReelPublishTests(unittest.TestCase):
+    def test_on_demand_publish_removes_old_archives_and_rebuilds_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            target = ReelDownloadBuilderTests().make_shared_bundle(base)
+            staging = base / "staging"
+            write(staging / "reel.html", b"<html></html>")
+            write(staging / "content_alignment.json", b"{}")
+            write(
+                staging / "manifest.json",
+                json.dumps(
+                    {
+                        "schema_version": "paper2reel.v1",
+                        "local_open": {"supported": True},
+                    }
+                ).encode(),
+            )
+            write(
+                staging / reel_downloads.DOWNLOAD_MANIFEST_PATH,
+                b"{}",
+            )
+            write(target / "assets" / "downloads" / "legacy.zip", b"legacy")
+
+            bootstrap.sync_reel_into_bundle(
+                staging,
+                target,
+                download_mode="on_demand",
+            )
+
+            self.assertFalse((target / "assets" / "downloads").exists())
+            manifest = read_json(target / reel_downloads.DOWNLOAD_MANIFEST_PATH)
+            self.assertEqual("on_demand", manifest["delivery"])
+            self.assertEqual(
+                [],
+                reel_downloads.validate_download_manifest(
+                    manifest,
+                    bundle_root=target,
+                    require_sources=True,
+                ),
+            )
+            root_manifest = read_json(target / "manifest.json")
+            reel_files = root_manifest["files"]["reel"]
+            self.assertEqual(
+                reel_downloads.DOWNLOAD_MANIFEST_PATH.as_posix(),
+                reel_files["downloads_manifest"],
+            )
+            self.assertNotIn("downloads_dir", reel_files)
 
 
 class ReelCopyNormalizationTests(unittest.TestCase):

--- a/ResearchStudio-Reel/skills/paper2reel/tests/test_download_archives.py
+++ b/ResearchStudio-Reel/skills/paper2reel/tests/test_download_archives.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = SKILL_DIR / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import build_poster_slides_view as builder  # noqa: E402
+import check_reel_package as checker  # noqa: E402
+
+
+def write(path: Path, contents: bytes = b"x") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(contents)
+
+
+def write_zip(path: Path, files: dict[str, bytes]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, contents in files.items():
+            archive.writestr(name, contents)
+
+
+def zip_names(path: Path) -> set[str]:
+    with zipfile.ZipFile(path) as archive:
+        return set(archive.namelist())
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class ReelDownloadBuilderTests(unittest.TestCase):
+    def make_shared_bundle(self, root: Path) -> Path:
+        bundle = root / "paper"
+        files = {
+            "poster.html": b"poster",
+            "poster.png": b"png",
+            "poster.pdf": b"pdf",
+            "poster.pptx": b"poster-pptx",
+            "video.mp4": b"video",
+            "video.pptx": b"video-pptx",
+            "video_no_subtitles.mp4": b"reel-internal-video",
+            "blog_en.docx": b"english",
+            "blog_zh.docx": b"chinese",
+            "assets/_pptx_build/dom.json": b"{}",
+            "assets/figures/figure1.png": b"figure",
+            "assets/figures/figure1.png.bak": b"backup",
+            "assets/fonts/font.woff2": b"font",
+            "assets/logos/logo.png": b"logo",
+            "assets/qr/code.png": b"qr",
+            "assets/captions/video.vtt": b"WEBVTT",
+            "assets/downloads/old.zip": b"old-download",
+            ".claude/scratch.txt": b"internal",
+        }
+        for relative, contents in files.items():
+            write(bundle / relative, contents)
+        return bundle
+
+    def test_shared_bundle_archives_are_separate_and_exclude_internal_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = self.make_shared_bundle(Path(tmp))
+            downloads = builder.build_downloads(
+                outdir=bundle,
+                poster_final_dir=bundle,
+                blog_final_dir=bundle,
+                video_final_dir=bundle,
+            )
+
+            self.assertEqual(
+                ["All", "Poster", "Video", "Blog"],
+                [item["label"] for item in downloads],
+            )
+            archive_dir = bundle / "assets" / "downloads"
+            names = {
+                name: zip_names(archive_dir / name)
+                for name in (
+                    "all_final.zip",
+                    "poster_final.zip",
+                    "video_final.zip",
+                    "blog_final.zip",
+                )
+            }
+
+            self.assertEqual(
+                {
+                    "video.mp4",
+                    "video.pptx",
+                    "assets/captions/video.vtt",
+                },
+                names["video_final.zip"],
+            )
+            self.assertEqual(
+                {"blog_en.docx", "blog_zh.docx"},
+                names["blog_final.zip"],
+            )
+            self.assertIn("poster.html", names["poster_final.zip"])
+            self.assertIn(
+                "assets/figures/figure1.png",
+                names["poster_final.zip"],
+            )
+            self.assertNotIn("video.mp4", names["poster_final.zip"])
+            self.assertNotIn("blog_en.docx", names["poster_final.zip"])
+
+            expected_all = (
+                names["poster_final.zip"]
+                | names["video_final.zip"]
+                | names["blog_final.zip"]
+            )
+            self.assertEqual(expected_all, names["all_final.zip"])
+            for archive_names in names.values():
+                self.assertFalse(
+                    any(name.startswith("assets/downloads/") for name in archive_names)
+                )
+                self.assertFalse(any(name.startswith(".claude/") for name in archive_names))
+                self.assertFalse(any(name.lower().endswith(".bak") for name in archive_names))
+
+            module_hashes = {
+                sha256(archive_dir / name)
+                for name in (
+                    "poster_final.zip",
+                    "video_final.zip",
+                    "blog_final.zip",
+                )
+            }
+            self.assertEqual(3, len(module_hashes))
+
+    def test_rebuilding_in_the_shared_bundle_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = self.make_shared_bundle(Path(tmp))
+            kwargs = {
+                "outdir": bundle,
+                "poster_final_dir": bundle,
+                "blog_final_dir": bundle,
+                "video_final_dir": bundle,
+            }
+            builder.build_downloads(**kwargs)
+            archive_dir = bundle / "assets" / "downloads"
+            archive_paths = sorted(archive_dir.glob("*_final.zip"))
+            first_names = {path.name: zip_names(path) for path in archive_paths}
+            first_sizes = {path.name: path.stat().st_size for path in archive_paths}
+
+            builder.build_downloads(**kwargs)
+            second_names = {path.name: zip_names(path) for path in archive_paths}
+            second_sizes = {path.name: path.stat().st_size for path in archive_paths}
+
+            self.assertEqual(first_names, second_names)
+            self.assertEqual(first_sizes, second_sizes)
+            for archive_names in second_names.values():
+                self.assertFalse(
+                    any("assets/downloads" in name for name in archive_names)
+                )
+                self.assertFalse(any(name.endswith(".zip") for name in archive_names))
+
+
+class ReelDownloadCheckerTests(unittest.TestCase):
+    def make_valid_archives(self, root: Path) -> Path:
+        downloads = root / "assets" / "downloads"
+        write_zip(downloads / "poster_final.zip", {"poster.html": b"poster"})
+        write_zip(downloads / "video_final.zip", {"video.mp4": b"video"})
+        write_zip(downloads / "blog_final.zip", {"blog_en.docx": b"blog"})
+        write_zip(
+            downloads / "all_final.zip",
+            {
+                "poster.html": b"poster",
+                "video.mp4": b"video",
+                "blog_en.docx": b"blog",
+            },
+        )
+        return downloads
+
+    def findings_for(self, root: Path) -> list[dict]:
+        findings: list[dict] = []
+        checker.validate_download_archives(findings, root)
+        return findings
+
+    def test_valid_separate_archives_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.make_valid_archives(root)
+            self.assertEqual([], self.findings_for(root))
+
+    def test_static_gate_runs_download_archive_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(checker, "validate_download_archives") as archive_gate:
+                checker.validate_static(root, contract={})
+            archive_gate.assert_called_once()
+            self.assertEqual(root.resolve(), archive_gate.call_args.args[1])
+
+    def test_corrupt_archive_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            downloads = self.make_valid_archives(root)
+            (downloads / "video_final.zip").write_bytes(b"not-a-zip")
+
+            codes = {finding["code"] for finding in self.findings_for(root)}
+            self.assertIn("DOWNLOAD_ARCHIVE_INVALID", codes)
+
+    def test_identical_module_archives_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            downloads = self.make_valid_archives(root)
+            shared_bytes = (downloads / "poster_final.zip").read_bytes()
+            (downloads / "video_final.zip").write_bytes(shared_bytes)
+            (downloads / "blog_final.zip").write_bytes(shared_bytes)
+
+            codes = {finding["code"] for finding in self.findings_for(root)}
+            self.assertIn("DOWNLOAD_MODULE_ARCHIVES_IDENTICAL", codes)
+
+    def test_cross_module_files_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            downloads = self.make_valid_archives(root)
+            write_zip(
+                downloads / "poster_final.zip",
+                {
+                    "poster.html": b"poster",
+                    "video.mp4": b"leaked-video",
+                },
+            )
+
+            codes = {finding["code"] for finding in self.findings_for(root)}
+            self.assertIn("DOWNLOAD_ARCHIVE_CROSS_MODULE_FILE", codes)
+
+    def test_internal_nested_download_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            downloads = self.make_valid_archives(root)
+            write_zip(
+                downloads / "blog_final.zip",
+                {
+                    "blog_en.docx": b"blog",
+                    "assets/downloads/old.zip": b"nested",
+                },
+            )
+
+            codes = {finding["code"] for finding in self.findings_for(root)}
+            self.assertIn("DOWNLOAD_ARCHIVE_INTERNAL_FILE", codes)
+
+
+class ReelCopyNormalizationTests(unittest.TestCase):
+    def test_katex_and_backups_are_normalized_only_in_reel_copies(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            original_html = (
+                '<html><head>'
+                '<link href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">'
+                '<script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>'
+                '<script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>'
+                "</head><body></body></html>"
+            )
+            (source / "poster.html").parent.mkdir(parents=True)
+            (source / "poster.html").write_text(original_html, encoding="utf-8")
+            write(source / "assets" / "figures" / "keep.png", b"keep")
+            write(source / "assets" / "figures" / "remove.png.bak", b"backup")
+
+            reel = root / "reel"
+            builder.copy_poster_bundle(source, reel)
+            copied_html_path = reel / "assets" / "poster" / "poster.html"
+            builder.prepare_poster_for_local_open(
+                copied_html_path,
+                root / "unused-mathjax-cache",
+            )
+
+            self.assertEqual(
+                original_html,
+                (source / "poster.html").read_text(encoding="utf-8"),
+            )
+            self.assertTrue(
+                (source / "assets" / "figures" / "remove.png.bak").is_file()
+            )
+            copied_html = copied_html_path.read_text(encoding="utf-8")
+            self.assertNotIn("cdn.jsdelivr.net/npm/katex", copied_html)
+            self.assertIn("katex/katex.min.css", copied_html)
+            self.assertTrue(
+                (copied_html_path.parent / "katex" / "katex.min.css").is_file()
+            )
+            self.assertFalse(
+                (
+                    reel
+                    / "assets"
+                    / "poster"
+                    / "assets"
+                    / "figures"
+                    / "remove.png.bak"
+                ).exists()
+            )
+
+            blog_figures = root / "blog-figures"
+            write(blog_figures / "keep.png", b"keep")
+            write(blog_figures / "remove.png.bak", b"backup")
+            mapping = builder.copy_blog_assets(reel, blog_figures)
+            self.assertIn("keep.png", mapping)
+            self.assertNotIn("remove.png.bak", mapping)
+            self.assertTrue((blog_figures / "remove.png.bak").is_file())
+            self.assertFalse(
+                (reel / "assets" / "blog" / "figures" / "remove.png.bak").exists()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ResearchStudio-Reel/skills/paper2video/SKILL.md
+++ b/ResearchStudio-Reel/skills/paper2video/SKILL.md
@@ -571,6 +571,11 @@ and re-render; do not bypass strict mode for final output. Only pass
 `--allow-missing-attention` for an explicitly user-approved degraded/debug run
 with no highlight.
 
+`audio_extra_files` remains visible in the QA report but is non-blocking: an
+unreferenced MP3 does not change `script.json`, the timeline, or either final
+MP4. Every other warning remains blocking under `--strict` or
+`--fail-on-warning`, and every error is always blocking.
+
 Write `$VIDEO_OUT/manifest.json` with `"layout": "v2-assets"` and root-relative
 paths for both MP4 deliverables plus `assets/audio/`, `assets/captions/`,
 `assets/slides/`, `assets/clips/`, and `assets/meta/reports/video_qa_report.json`.

--- a/ResearchStudio-Reel/skills/paper2video/scripts/check_video_package.py
+++ b/ResearchStudio-Reel/skills/paper2video/scripts/check_video_package.py
@@ -49,6 +49,7 @@ NS = {
     "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
 }
 SCHEMA_VERSION = "paper2video_qa.v1"
+NON_BLOCKING_WARNING_CODES = frozenset({"audio_extra_files"})
 
 
 @dataclass
@@ -82,6 +83,28 @@ def utc_now() -> str:
 
 def add(findings: list[Finding], severity: str, code: str, message: str, *, location: str | None = None, **data: Any) -> None:
     findings.append(Finding(severity=severity, code=code, message=message, location=location, data=data))
+
+
+def findings_pass_gate(
+    findings: list[Finding],
+    *,
+    fail_on_warning: bool,
+) -> bool:
+    """Return whether findings pass the final package gate.
+
+    Unreferenced MP3s remain visible in the report but do not invalidate the
+    delivered timeline or MP4. Every other warning remains blocking when
+    strict/fail-on-warning policy is active, and errors always block.
+    """
+    if any(finding.severity == "error" for finding in findings):
+        return False
+    if not fail_on_warning:
+        return True
+    return not any(
+        finding.severity == "warning"
+        and finding.code not in NON_BLOCKING_WARNING_CODES
+        for finding in findings
+    )
 
 
 def read_json(path: Path) -> Any:
@@ -1762,7 +1785,7 @@ def main() -> None:
         "info": sum(1 for f in findings if f.severity == "info"),
     }
     fail_on_warning = args.fail_on_warning or args.strict
-    passed = counts["error"] == 0 and (counts["warning"] == 0 or not fail_on_warning)
+    passed = findings_pass_gate(findings, fail_on_warning=fail_on_warning)
     report = {
         "schema_version": SCHEMA_VERSION,
         "created_at": utc_now(),

--- a/ResearchStudio-Reel/skills/paper2video/scripts/focus_contract.py
+++ b/ResearchStudio-Reel/skills/paper2video/scripts/focus_contract.py
@@ -1,0 +1,79 @@
+"""Canonical visual-attention option contract for Paper2Video."""
+
+from __future__ import annotations
+
+
+VIDEO_POINTER_STYLES = ("cursor", "laser", "none")
+VIDEO_SPOTLIGHT_STYLES = ("spotlight", "box", "none")
+VIDEO_HIGHLIGHT_STYLES = (
+    "box",
+    "spotlight",
+    "cursor",
+    "box_cursor",
+    "spotlight_cursor",
+    "laser",
+    "box_laser",
+    "spotlight_laser",
+)
+
+VIDEO_DEFAULT_POINTER_STYLE = "laser"
+VIDEO_DEFAULT_SPOTLIGHT_STYLE = "spotlight"
+
+_LEGACY_FOCUS_PARTS = {
+    "box": ("none", "box"),
+    "spotlight": ("none", "spotlight"),
+    "cursor": ("cursor", "none"),
+    "box_cursor": ("cursor", "box"),
+    "spotlight_cursor": ("cursor", "spotlight"),
+    "laser": ("laser", "none"),
+    "box_laser": ("laser", "box"),
+    "spotlight_laser": ("laser", "spotlight"),
+    "none": ("none", "none"),
+}
+
+
+def normalize_video_focus(
+    pointer_style: object = None,
+    spotlight_style: object = None,
+    legacy_style: object = None,
+) -> tuple[str, str, str]:
+    """Return validated ``(pointer, spotlight, renderer_style)`` values.
+
+    Older saved jobs sent one combined ``highlight_style``. New submissions
+    send independent pointer and spotlight axes. Supporting both keeps queued
+    or retried jobs deterministic while exposing every 3x3 combination.
+    """
+
+    pointer_raw = str(pointer_style or "").strip().lower()
+    spotlight_raw = str(spotlight_style or "").strip().lower()
+    legacy_raw = str(legacy_style or "").strip().lower()
+
+    if not pointer_raw and not spotlight_raw and legacy_raw in _LEGACY_FOCUS_PARTS:
+        pointer, spotlight = _LEGACY_FOCUS_PARTS[legacy_raw]
+    else:
+        pointer = (
+            pointer_raw
+            if pointer_raw in VIDEO_POINTER_STYLES
+            else VIDEO_DEFAULT_POINTER_STYLE
+        )
+        spotlight = (
+            spotlight_raw
+            if spotlight_raw in VIDEO_SPOTLIGHT_STYLES
+            else VIDEO_DEFAULT_SPOTLIGHT_STYLE
+        )
+
+    if pointer == "none" and spotlight == "none":
+        renderer_style = "none"
+    elif spotlight == "none":
+        renderer_style = pointer
+    elif pointer == "none":
+        renderer_style = spotlight
+    else:
+        renderer_style = f"{spotlight}_{pointer}"
+
+    if renderer_style != "none" and renderer_style not in VIDEO_HIGHLIGHT_STYLES:
+        pointer = VIDEO_DEFAULT_POINTER_STYLE
+        spotlight = VIDEO_DEFAULT_SPOTLIGHT_STYLE
+        renderer_style = f"{spotlight}_{pointer}"
+
+    return pointer, spotlight, renderer_style

--- a/ResearchStudio-Reel/skills/paper2video/scripts/ppt_options_contract.py
+++ b/ResearchStudio-Reel/skills/paper2video/scripts/ppt_options_contract.py
@@ -1,0 +1,577 @@
+"""Canonical Paper2Video and PPT-Master option contract.
+
+Descriptive fields such as audience, color, and typography remain bounded
+strings because PPT-Master intentionally generates those from the paper;
+every enumerable field is closed over the catalog below.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping
+
+
+CATALOG_VERSION = "paper2video-ppt-options.v1"
+
+PPT_OPTIONS_PUBLIC_CATALOG = {
+    "narrative_modes": (
+        {"id": "auto", "label": "Auto · recommended"},
+        {"id": "pyramid", "label": "Pyramid"},
+        {"id": "narrative", "label": "Narrative"},
+        {"id": "instructional", "label": "Instructional"},
+        {"id": "showcase", "label": "Showcase"},
+        {"id": "briefing", "label": "Briefing"},
+    ),
+    "visual_style_groups": (
+        {
+            "label": "Corporate / product",
+            "options": (
+                {"id": "swiss-minimal", "label": "Swiss minimal"},
+                {"id": "soft-rounded", "label": "Soft rounded"},
+                {"id": "glassmorphism", "label": "Glassmorphism"},
+                {"id": "dark-tech", "label": "Dark tech"},
+                {"id": "blueprint", "label": "Blueprint"},
+            ),
+        },
+        {
+            "label": "Editorial / data",
+            "options": (
+                {"id": "editorial", "label": "Editorial"},
+                {"id": "photo-editorial", "label": "Photo editorial"},
+                {"id": "data-journalism", "label": "Data journalism"},
+            ),
+        },
+        {
+            "label": "Expressive",
+            "options": (
+                {"id": "brutalist", "label": "Brutalist"},
+                {"id": "memphis", "label": "Memphis"},
+                {"id": "zine", "label": "Zine"},
+                {"id": "vintage-poster", "label": "Vintage poster"},
+                {"id": "paper-cut", "label": "Paper cut"},
+                {"id": "sketch-notes", "label": "Sketch notes"},
+                {"id": "ink-notes", "label": "Ink notes"},
+                {"id": "chalkboard", "label": "Chalkboard"},
+                {"id": "ink-wash", "label": "Ink wash"},
+                {"id": "pixel-art", "label": "Pixel art"},
+            ),
+        },
+    ),
+    "image_sources": (
+        {"id": "auto", "label": "Auto"},
+        {"id": "ai", "label": "AI-generated", "requires_image_api": True},
+        {"id": "web", "label": "Web-sourced"},
+        {"id": "provided", "label": "Paper / provided"},
+        {"id": "placeholder", "label": "Placeholder"},
+        {"id": "none", "label": "No images"},
+    ),
+    "formula_policies": (
+        {"id": "mixed", "label": "Mixed · complex formulas rendered"},
+        {"id": "render-all", "label": "Render all formulas"},
+        {"id": "text-only", "label": "Editable text only"},
+    ),
+    "delivery_purposes": (
+        {"id": "text", "label": "Read-close"},
+        {"id": "balanced", "label": "Balanced"},
+        {"id": "presentation", "label": "Presentation"},
+    ),
+    "icon_libraries": (
+        {"id": "auto", "label": "Auto"},
+        {"id": "chunk-filled", "label": "Chunk filled"},
+        {"id": "tabler-filled", "label": "Tabler filled"},
+        {"id": "tabler-outline", "label": "Tabler outline"},
+        {"id": "phosphor-duotone", "label": "Phosphor duotone"},
+        {"id": "emoji", "label": "Emoji"},
+        {"id": "none", "label": "No icons"},
+    ),
+    "image_ai_paths": (
+        {"id": "auto", "label": "Auto"},
+        {"id": "api", "label": "Configured API"},
+        {"id": "host-native", "label": "Host-native"},
+        {"id": "manual", "label": "Manual"},
+    ),
+    "transitions": tuple(
+        {"id": value, "label": value}
+        for value in (
+            "fade",
+            "push",
+            "wipe",
+            "split",
+            "strips",
+            "cover",
+            "random",
+            "none",
+        )
+    ),
+    "animations": tuple(
+        {"id": value, "label": value}
+        for value in (
+            "none",
+            "auto",
+            "mixed",
+            "random",
+            "appear",
+            "fade",
+            "fly",
+            "cut",
+            "zoom",
+            "wipe",
+            "split",
+            "blinds",
+            "checkerboard",
+            "dissolve",
+            "random_bars",
+            "peek",
+            "wheel",
+            "box",
+            "circle",
+            "diamond",
+            "plus",
+            "strips",
+            "wedge",
+            "stretch",
+            "expand",
+            "swivel",
+        )
+    ),
+    "animation_triggers": tuple(
+        {"id": value, "label": value}
+        for value in ("on-click", "with-previous", "after-previous")
+    ),
+}
+
+
+def _ids(name: str) -> tuple[str, ...]:
+    return tuple(str(option["id"]) for option in PPT_OPTIONS_PUBLIC_CATALOG[name])
+
+
+PPT_MASTER_MODES = _ids("narrative_modes")
+PPT_MASTER_VISUAL_STYLES = (
+    "auto",
+    *tuple(
+        str(option["id"])
+        for group in PPT_OPTIONS_PUBLIC_CATALOG["visual_style_groups"]
+        for option in group["options"]
+    ),
+)
+PPT_MASTER_DELIVERY_PURPOSES = _ids("delivery_purposes")
+PPT_MASTER_ICONS = _ids("icon_libraries")
+PPT_MASTER_IMAGE_USAGE = _ids("image_sources")
+PPT_MASTER_IMAGE_AI_PATHS = _ids("image_ai_paths")
+PPT_MASTER_FORMULA_POLICIES = _ids("formula_policies")
+PPT_MASTER_TRANSITIONS = _ids("transitions")
+PPT_MASTER_ANIMATIONS = _ids("animations")
+PPT_MASTER_ANIMATION_TRIGGERS = _ids("animation_triggers")
+
+_CONCRETE_MODES = tuple(value for value in PPT_MASTER_MODES if value != "auto")
+_CONCRETE_VISUAL_STYLES = tuple(
+    value for value in PPT_MASTER_VISUAL_STYLES if value != "auto"
+)
+_CONCRETE_ICONS = tuple(value for value in PPT_MASTER_ICONS if value != "auto")
+_CONCRETE_IMAGE_USAGE = tuple(
+    value for value in PPT_MASTER_IMAGE_USAGE if value != "auto"
+)
+
+PPT_RESOLVED_SCHEMA = {
+    "$id": CATALOG_VERSION,
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "page_count",
+        "mode",
+        "visual_style",
+        "delivery_purpose",
+        "target_audience",
+        "color_direction",
+        "typography_direction",
+        "icon_library",
+        "formula_policy",
+        "image_usage",
+        "image_ai_path",
+    ],
+    "properties": {
+        "page_count": {"type": "integer", "minimum": 1, "maximum": 60},
+        "mode": {"type": "string", "enum": list(_CONCRETE_MODES)},
+        "visual_style": {
+            "type": "string",
+            "enum": list(_CONCRETE_VISUAL_STYLES),
+        },
+        "delivery_purpose": {
+            "type": "string",
+            "enum": list(PPT_MASTER_DELIVERY_PURPOSES),
+        },
+        "target_audience": {"type": "string", "minLength": 3, "maxLength": 500},
+        "color_direction": {"type": "string", "minLength": 3, "maxLength": 500},
+        "typography_direction": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 500,
+        },
+        "icon_library": {"type": "string", "enum": list(_CONCRETE_ICONS)},
+        "formula_policy": {
+            "type": "string",
+            "enum": list(PPT_MASTER_FORMULA_POLICIES),
+        },
+        "image_usage": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": True,
+            "items": {"type": "string", "enum": list(_CONCRETE_IMAGE_USAGE)},
+        },
+        "image_ai_path": {
+            "type": "string",
+            "enum": ["api", "not-used"],
+        },
+    },
+}
+
+_RESOLVED_KEYS = tuple(PPT_RESOLVED_SCHEMA["required"])
+_HEX_COLOR = re.compile(r"#[0-9a-fA-F]{6}\b")
+
+
+class PptOptionsValidationError(ValueError):
+    """A structured Auto resolution violates the shared PPT option contract."""
+
+
+def prompt_catalog() -> dict:
+    """Return the compact machine-facing enum catalog used in resolver prompts."""
+    return {
+        "catalog_version": CATALOG_VERSION,
+        "mode": list(_CONCRETE_MODES),
+        "visual_style": list(_CONCRETE_VISUAL_STYLES),
+        "delivery_purpose": list(PPT_MASTER_DELIVERY_PURPOSES),
+        "icon_library": list(_CONCRETE_ICONS),
+        "formula_policy": list(PPT_MASTER_FORMULA_POLICIES),
+        "image_usage": list(_CONCRETE_IMAGE_USAGE),
+        "image_ai_path": ["api", "not-used"],
+    }
+
+
+def export_flags_from_options(opts: Mapping[str, object]) -> list[str]:
+    """Derive the exact svg_to_pptx flags from sanitized options."""
+    transition = str(opts.get("ppt_transition") or "fade")
+    animation = str(opts.get("ppt_animation") or "none")
+    flags = [f"-t {transition}", f"-a {animation}"]
+    if animation != "none":
+        flags.append(
+            f"--animation-trigger "
+            f"{opts.get('ppt_animation_trigger') or 'after-previous'}"
+        )
+    if bool(opts.get("ppt_native_objects")):
+        flags.append("--native-objects")
+    if bool(opts.get("ppt_strict_line_fidelity")):
+        flags.append("--no-merge")
+    return flags
+
+
+def _page_bounds(value: object) -> tuple[int, int] | None:
+    raw = str(value or "auto").strip().lower()
+    if raw == "auto":
+        return None
+    match = re.fullmatch(r"(\d{1,2})(?:-(\d{1,2}))?", raw)
+    if not match:
+        raise PptOptionsValidationError("requested page count is invalid")
+    lower = int(match.group(1))
+    upper = int(match.group(2) or lower)
+    if lower < 1 or upper > 60 or lower > upper:
+        raise PptOptionsValidationError("requested page count is outside 1-60")
+    return lower, upper
+
+
+def _bounded_text(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise PptOptionsValidationError(f"{key} must be a string")
+    value = value.strip()
+    if not 3 <= len(value) <= 500:
+        raise PptOptionsValidationError(f"{key} must contain 3-500 characters")
+    return value
+
+
+def validate_resolved_ppt_options(
+    payload: object,
+    requested: Mapping[str, object],
+    *,
+    image_api_available: bool,
+) -> dict:
+    """Validate a resolver response against one schema and the user's request."""
+    if not isinstance(payload, Mapping):
+        raise PptOptionsValidationError("resolved PPT options must be a JSON object")
+    if set(payload) != set(_RESOLVED_KEYS):
+        missing = sorted(set(_RESOLVED_KEYS) - set(payload))
+        extra = sorted(set(payload) - set(_RESOLVED_KEYS))
+        raise PptOptionsValidationError(
+            f"resolved PPT options have wrong keys; missing={missing}, extra={extra}"
+        )
+
+    page_count = payload.get("page_count")
+    if isinstance(page_count, bool) or not isinstance(page_count, int):
+        raise PptOptionsValidationError("page_count must be an integer")
+    if not 1 <= page_count <= 60:
+        raise PptOptionsValidationError("page_count must be between 1 and 60")
+
+    def enum_value(key: str, allowed: tuple[str, ...]) -> str:
+        value = payload.get(key)
+        if not isinstance(value, str) or value not in allowed:
+            raise PptOptionsValidationError(
+                f"{key} must be one of {list(allowed)}"
+            )
+        return value
+
+    mode = enum_value("mode", _CONCRETE_MODES)
+    visual_style = enum_value("visual_style", _CONCRETE_VISUAL_STYLES)
+    delivery_purpose = enum_value(
+        "delivery_purpose", PPT_MASTER_DELIVERY_PURPOSES
+    )
+    icon_library = enum_value("icon_library", _CONCRETE_ICONS)
+    formula_policy = enum_value("formula_policy", PPT_MASTER_FORMULA_POLICIES)
+    image_ai_path = enum_value("image_ai_path", ("api", "not-used"))
+
+    target_audience = _bounded_text(payload, "target_audience")
+    color_direction = _bounded_text(payload, "color_direction")
+    typography_direction = _bounded_text(payload, "typography_direction")
+
+    image_usage_raw = payload.get("image_usage")
+    if not isinstance(image_usage_raw, list) or not image_usage_raw:
+        raise PptOptionsValidationError("image_usage must be a non-empty array")
+    if any(
+        not isinstance(value, str) or value not in _CONCRETE_IMAGE_USAGE
+        for value in image_usage_raw
+    ):
+        raise PptOptionsValidationError(
+            f"image_usage entries must be selected from {list(_CONCRETE_IMAGE_USAGE)}"
+        )
+    image_usage = list(dict.fromkeys(image_usage_raw))
+    if len(image_usage) != len(image_usage_raw):
+        raise PptOptionsValidationError("image_usage must not contain duplicates")
+    if "none" in image_usage and len(image_usage) != 1:
+        raise PptOptionsValidationError("image_usage `none` is exclusive")
+    if not image_api_available and "ai" in image_usage:
+        raise PptOptionsValidationError("AI images require a configured API")
+    if ("ai" in image_usage) != (image_ai_path == "api"):
+        raise PptOptionsValidationError(
+            "image_ai_path must be `api` exactly when image_usage contains `ai`"
+        )
+
+    page_bounds = _page_bounds(requested.get("ppt_page_count"))
+    if page_bounds and not page_bounds[0] <= page_count <= page_bounds[1]:
+        raise PptOptionsValidationError(
+            f"page_count must stay inside requested range {page_bounds}"
+        )
+
+    exact_enums = {
+        "mode": ("ppt_mode", mode),
+        "visual_style": ("ppt_visual_style", visual_style),
+        "delivery_purpose": ("ppt_delivery_purpose", delivery_purpose),
+        "icon_library": ("ppt_icons", icon_library),
+        "formula_policy": ("ppt_formula_policy", formula_policy),
+    }
+    for label, (request_key, resolved_value) in exact_enums.items():
+        requested_value = str(requested.get(request_key) or "auto").strip()
+        if requested_value != "auto" and resolved_value != requested_value:
+            raise PptOptionsValidationError(
+                f"{label} must preserve explicit request {requested_value}"
+            )
+
+    exact_text = {
+        "target_audience": ("ppt_audience", target_audience),
+        "color_direction": ("ppt_color", color_direction),
+        "typography_direction": ("ppt_typography", typography_direction),
+    }
+    for label, (request_key, resolved_value) in exact_text.items():
+        requested_value = str(requested.get(request_key) or "").strip()
+        if requested_value and resolved_value != requested_value:
+            raise PptOptionsValidationError(
+                f"{label} must preserve the user's exact text"
+            )
+
+    requested_usage = list(requested.get("ppt_image_usage") or ["auto"])
+    if requested_usage != ["auto"] and set(image_usage) != set(requested_usage):
+        raise PptOptionsValidationError(
+            "image_usage must preserve the explicitly selected sources"
+        )
+
+    return {
+        "page_count": page_count,
+        "mode": mode,
+        "visual_style": visual_style,
+        "delivery_purpose": delivery_purpose,
+        "target_audience": target_audience,
+        "color_direction": color_direction,
+        "typography_direction": typography_direction,
+        "icon_library": icon_library,
+        "formula_policy": formula_policy,
+        "image_usage": image_usage,
+        "image_ai_path": image_ai_path,
+    }
+
+
+def _fallback_page_count(requested: Mapping[str, object]) -> int:
+    bounds = _page_bounds(requested.get("ppt_page_count"))
+    if bounds:
+        return round((bounds[0] + bounds[1]) / 2)
+    duration = str(requested.get("duration") or "auto")
+    try:
+        minutes = float(duration)
+    except ValueError:
+        minutes = math.nan
+    if math.isfinite(minutes):
+        return max(5, min(20, round(minutes * 2)))
+    return 10
+
+
+def fallback_resolved_ppt_options(
+    requested: Mapping[str, object],
+    *,
+    image_api_available: bool,
+) -> dict:
+    """Return deterministic, canonical values when both resolver attempts fail."""
+    requested_usage = list(requested.get("ppt_image_usage") or ["auto"])
+    image_usage = (
+        ["provided", "placeholder"]
+        if requested_usage == ["auto"]
+        else requested_usage
+    )
+    if not image_api_available:
+        image_usage = [value for value in image_usage if value != "ai"]
+    if not image_usage:
+        image_usage = ["provided", "placeholder"]
+
+    payload = {
+        "page_count": _fallback_page_count(requested),
+        "mode": (
+            "narrative"
+            if requested.get("ppt_mode") in (None, "", "auto")
+            else requested["ppt_mode"]
+        ),
+        "visual_style": (
+            "editorial"
+            if requested.get("ppt_visual_style") in (None, "", "auto")
+            else requested["ppt_visual_style"]
+        ),
+        "delivery_purpose": requested.get("ppt_delivery_purpose")
+        or "presentation",
+        "target_audience": requested.get("ppt_audience")
+        or "Research readers and technical practitioners",
+        "color_direction": requested.get("ppt_color")
+        or (
+            "Light editorial palette: background #F8FAFC, primary #0F172A, "
+            "accent #2563EB, body text #1E293B"
+        ),
+        "typography_direction": requested.get("ppt_typography")
+        or "Aptos headings with Aptos body text and a clear presentation hierarchy",
+        "icon_library": (
+            "tabler-outline"
+            if requested.get("ppt_icons") in (None, "", "auto")
+            else requested["ppt_icons"]
+        ),
+        "formula_policy": requested.get("ppt_formula_policy") or "mixed",
+        "image_usage": image_usage,
+        "image_ai_path": "api" if "ai" in image_usage else "not-used",
+    }
+    return validate_resolved_ppt_options(
+        payload,
+        requested,
+        image_api_available=image_api_available,
+    )
+
+
+def merge_resolved_ppt_options(
+    requested: Mapping[str, object],
+    resolved: Mapping[str, object],
+) -> dict:
+    """Overlay one validated resolution onto sanitized Paper2Video options."""
+    merged = dict(requested)
+    merged["_ppt_user_request"] = {
+        "ppt_audience": str(requested.get("ppt_audience") or ""),
+        "ppt_color": str(requested.get("ppt_color") or ""),
+        "ppt_typography": str(requested.get("ppt_typography") or ""),
+    }
+    merged.update(
+        {
+            "ppt_page_count": str(resolved["page_count"]),
+            "ppt_mode": resolved["mode"],
+            "ppt_visual_style": resolved["visual_style"],
+            "ppt_delivery_purpose": resolved["delivery_purpose"],
+            "ppt_audience": resolved["target_audience"],
+            "ppt_color": resolved["color_direction"],
+            "ppt_typography": resolved["typography_direction"],
+            "ppt_icons": resolved["icon_library"],
+            "ppt_formula_policy": resolved["formula_policy"],
+            "ppt_image_usage": list(resolved["image_usage"]),
+            "ppt_image_ai_path": resolved["image_ai_path"],
+        }
+    )
+    return merged
+
+
+def resolution_prompt(
+    pdf_abs: str,
+    requested: Mapping[str, object],
+    *,
+    image_api_available: bool,
+    previous_error: str = "",
+) -> str:
+    """Build the read-only JSON-only Auto resolution prompt."""
+    retry = (
+        f"\nYour previous response failed validation: {previous_error}\n"
+        "Correct it without adding keys or inventing enum ids.\n"
+        if previous_error
+        else ""
+    )
+    context = {
+        "pdf_path": pdf_abs,
+        "paper_title": requested.get("paper_title") or "",
+        "target_duration_minutes": requested.get("duration") or "auto",
+        "additional_requirements": requested.get("requirements") or "",
+        "requested_ppt_options": {
+            key: requested.get(key)
+            for key in (
+                "ppt_page_count",
+                "ppt_mode",
+                "ppt_visual_style",
+                "ppt_delivery_purpose",
+                "ppt_audience",
+                "ppt_color",
+                "ppt_typography",
+                "ppt_icons",
+                "ppt_formula_policy",
+                "ppt_image_usage",
+            )
+        },
+        "image_api_available": image_api_available,
+    }
+    return (
+        "Resolve Paper2Video's PPT-Master Auto options before any deck generation. "
+        "This is a read-only planning call: inspect the PDF as needed, do not modify "
+        "files, and return exactly one JSON object with no Markdown or prose.\n"
+        "Every enumerable value MUST be copied verbatim from canonical_catalog. "
+        "Never create, combine, alias, or rename an enum id. Preserve every explicit "
+        "non-Auto request exactly. Descriptive audience/color/typography fields may "
+        "be paper-specific strings; an Auto color_direction must include at least "
+        "two concrete #RRGGBB values and typography_direction must name its primary "
+        "font. Set image_ai_path to `api` exactly when image_usage contains `ai`, "
+        "otherwise `not-used`.\n"
+        f"{retry}"
+        f"canonical_catalog = {json.dumps(prompt_catalog(), ensure_ascii=False)}\n"
+        f"json_schema = {json.dumps(PPT_RESOLVED_SCHEMA, ensure_ascii=False)}\n"
+        f"context = {json.dumps(context, ensure_ascii=False)}\n"
+    )
+
+
+def parse_json_object(text: str) -> dict:
+    """Extract exactly one JSON object from a model's final text."""
+    raw = str(text or "").strip()
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(raw):
+        if char != "{":
+            continue
+        try:
+            value, end = decoder.raw_decode(raw[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict) and not raw[index + end :].strip(" \t\r\n`"):
+            return value
+    raise PptOptionsValidationError("resolver did not return one clean JSON object")

--- a/ResearchStudio-Reel/skills/paper2video/scripts/ppt_stage_validator.py
+++ b/ResearchStudio-Reel/skills/paper2video/scripts/ppt_stage_validator.py
@@ -1,0 +1,282 @@
+"""Structured validation for Paper2Video's PPT-Master audit.
+
+PPT-Master may phrase an automatically resolved direction differently in its
+receipt, design specification, and execution lock. The validator therefore
+checks concrete locked fields and semantic agreement instead of requiring one
+generated sentence to be copied verbatim between artifacts.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import unicodedata
+from collections.abc import Sequence
+
+
+_AUDIENCE_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "for",
+        "following",
+        "of",
+        "the",
+        "to",
+        "work",
+    }
+)
+_HEX_COLOR = re.compile(r"^#[0-9a-fA-F]{6}$")
+_SPEC_LOCK_COLOR_KEYS = {
+    # PPT-Master spec-lock/v1 uses bg/text. The longer names are accepted for
+    # historical Paper2Video projects and older confirmation-UI receipts. A
+    # few generated locks used ``body`` in the colors section (mirroring the
+    # typography size key); it is unambiguous there, so retain it as a narrow
+    # compatibility alias while requiring new locks to emit ``body_text``.
+    "background": ("bg", "background"),
+    "primary": ("primary",),
+    "accent": ("accent",),
+    "body_text": ("text", "body_text", "body"),
+}
+
+
+def spec_lock_value(lock_text: str, section: str, key: str) -> str:
+    """Read one scalar from PPT-Master's markdown execution lock."""
+    section_match = re.search(
+        rf"(?ms)^##\s+{re.escape(section)}\s*$\n(.*?)(?=^##\s+|\Z)",
+        lock_text,
+    )
+    if not section_match:
+        return ""
+    row = re.search(
+        rf"(?m)^-\s+{re.escape(key)}:\s*(.+?)\s*$",
+        section_match.group(1),
+    )
+    return row.group(1).strip().strip("\"'") if row else ""
+
+
+def design_table_value(design_text: str, item: str) -> str:
+    """Read a two-column value from a markdown table in design_spec.md."""
+    wanted = _normalize_text(item)
+    for line in design_text.splitlines():
+        if not line.lstrip().startswith("|"):
+            continue
+        cells = [
+            cell.strip().strip("*`")
+            for cell in line.strip().strip("|").split("|")
+        ]
+        if len(cells) >= 2 and _normalize_text(cells[0]) == wanted:
+            return cells[1].strip()
+    return ""
+
+
+def _spec_lock_alias_value(
+    lock_text: str,
+    section: str,
+    semantic_role: str,
+    keys: Sequence[str],
+) -> str:
+    """Resolve one schema role without silently accepting conflicting aliases."""
+    found = [
+        (key, spec_lock_value(lock_text, section, key))
+        for key in keys
+    ]
+    found = [(key, value) for key, value in found if value]
+    if not found:
+        return ""
+    distinct = {value.casefold() for _, value in found}
+    if len(distinct) != 1:
+        detail = ", ".join(f"{key}={value}" for key, value in found)
+        raise RuntimeError(
+            "PPT-Master spec_lock.md has conflicting aliases for "
+            f"{semantic_role}: {detail}"
+        )
+    return found[0][1]
+
+
+def _normalize_text(value: object) -> str:
+    text = unicodedata.normalize("NFKC", str(value or "")).casefold()
+    return " ".join(re.findall(r"[^\W_]+", text, flags=re.UNICODE))
+
+
+def _audience_tokens(value: str) -> set[str]:
+    tokens = set(_normalize_text(value).split()) - _AUDIENCE_STOP_WORDS
+    if "ml" in tokens:
+        tokens.update({"machine", "learning"})
+    if "ai" in tokens:
+        tokens.update({"artificial", "intelligence"})
+    return tokens
+
+
+def _material_audience_overlap(left: str, right: str) -> bool:
+    left_tokens = _audience_tokens(left)
+    right_tokens = _audience_tokens(right)
+    if not left_tokens or not right_tokens:
+        return False
+    overlap = left_tokens & right_tokens
+    return len(overlap) >= min(2, len(left_tokens), len(right_tokens))
+
+
+def _contains_normalized(haystack: str, needle: str) -> bool:
+    normalized_needle = _normalize_text(needle)
+    return bool(normalized_needle) and normalized_needle in _normalize_text(haystack)
+
+
+def _positive_number(value: str) -> bool:
+    try:
+        return float(value) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def audit_descriptive_options(
+    applied: dict,
+    opts: dict,
+    lock_text: str,
+    design_text: str,
+) -> None:
+    """Verify audience, typography, and color against executable PPT locks.
+
+    Explicit choices must be copied exactly into the applied-options receipt
+    and be recorded in the generated design/lock. Auto choices may be worded
+    differently, but must resolve to mutually consistent structured values in
+    both design_spec.md and spec_lock.md.
+    """
+    requested_audience = str(opts.get("ppt_audience") or "").strip()
+    applied_audience = str(applied.get("target_audience") or "").strip()
+    locked_audience = spec_lock_value(lock_text, "communication", "audience")
+    designed_audience = design_table_value(design_text, "Target Audience")
+    if not applied_audience:
+        raise RuntimeError("PPT-Master did not resolve a target audience")
+    if not locked_audience or not designed_audience:
+        raise RuntimeError(
+            "PPT-Master audience is missing from spec_lock.md or design_spec.md"
+        )
+    if requested_audience:
+        if applied_audience != requested_audience:
+            raise RuntimeError("PPT-Master target audience does not match the request")
+        if not (
+            _contains_normalized(locked_audience, requested_audience)
+            or _contains_normalized(designed_audience, requested_audience)
+        ):
+            raise RuntimeError(
+                "PPT-Master did not record the requested target audience in its design lock"
+            )
+    elif not (
+        _material_audience_overlap(applied_audience, locked_audience)
+        and _material_audience_overlap(locked_audience, designed_audience)
+    ):
+        raise RuntimeError(
+            "PPT-Master Auto target audience is inconsistent across its receipt and design lock"
+        )
+
+    requested_typography = str(opts.get("ppt_typography") or "").strip()
+    applied_typography = str(applied.get("typography_direction") or "").strip()
+    font_family = spec_lock_value(lock_text, "typography", "font_family")
+    body_size = spec_lock_value(lock_text, "typography", "body")
+    title_size = spec_lock_value(lock_text, "typography", "title")
+    if not applied_typography:
+        raise RuntimeError("PPT-Master did not resolve a typography direction")
+    if not font_family or not _positive_number(body_size) or not _positive_number(title_size):
+        raise RuntimeError(
+            "PPT-Master spec_lock.md is missing executable typography values"
+        )
+    primary_font = font_family.split(",", 1)[0].strip().strip("\"'")
+    if not _contains_normalized(design_text, primary_font):
+        raise RuntimeError(
+            "PPT-Master design_spec.md does not match the font in spec_lock.md"
+        )
+    if requested_typography:
+        if applied_typography != requested_typography:
+            raise RuntimeError(
+                "PPT-Master typography direction does not match the request"
+            )
+        if not _contains_normalized(design_text, requested_typography):
+            raise RuntimeError(
+                "PPT-Master did not record the requested typography direction in design_spec.md"
+            )
+    elif not _contains_normalized(applied_typography, primary_font):
+        raise RuntimeError(
+            "PPT-Master Auto typography receipt does not match the font locked in its design"
+        )
+
+    requested_color = str(opts.get("ppt_color") or "").strip()
+    applied_color = str(applied.get("color_direction") or "").strip()
+    locked_colors = {
+        role: _spec_lock_alias_value(
+            lock_text,
+            "colors",
+            role,
+            keys,
+        )
+        for role, keys in _SPEC_LOCK_COLOR_KEYS.items()
+    }
+    if not applied_color:
+        raise RuntimeError("PPT-Master did not resolve a color direction")
+    invalid_color_roles = [
+        role
+        for role, value in locked_colors.items()
+        if not _HEX_COLOR.fullmatch(value)
+    ]
+    if invalid_color_roles:
+        raise RuntimeError(
+            "PPT-Master spec_lock.md is missing or has invalid executable HEX "
+            "color roles: " + ", ".join(invalid_color_roles)
+        )
+    missing_design_colors = [
+        value
+        for value in locked_colors.values()
+        if value.casefold() not in design_text.casefold()
+    ]
+    if missing_design_colors:
+        raise RuntimeError(
+            "PPT-Master design_spec.md does not match the colors in spec_lock.md"
+        )
+    if requested_color:
+        if applied_color != requested_color:
+            raise RuntimeError("PPT-Master color direction does not match the request")
+        if not _contains_normalized(design_text, requested_color):
+            raise RuntimeError(
+                "PPT-Master did not record the requested color direction in design_spec.md"
+            )
+    else:
+        receipt_color_count = sum(
+            value.casefold() in applied_color.casefold()
+            for value in locked_colors.values()
+        )
+        if receipt_color_count < 2:
+            raise RuntimeError(
+                "PPT-Master Auto color receipt does not describe the palette locked in its design"
+            )
+
+
+def normalize_export_flag_tokens(
+    raw: str | Sequence[object] | None,
+) -> list[str]:
+    """Normalize either grouped or tokenized JSON export flags."""
+    if isinstance(raw, str):
+        chunks = [raw]
+    elif isinstance(raw, Sequence):
+        chunks = [str(item).strip() for item in raw if str(item).strip()]
+    else:
+        return []
+
+    tokens: list[str] = []
+    try:
+        for chunk in chunks:
+            tokens.extend(shlex.split(chunk))
+    except ValueError:
+        return []
+    return tokens
+
+
+def audit_export_flags(applied_raw: object, expected_flags: Sequence[str]) -> None:
+    """Require the exact svg_to_pptx options, independent of JSON grouping."""
+    applied_tokens = normalize_export_flag_tokens(applied_raw)  # type: ignore[arg-type]
+    expected_tokens = normalize_export_flag_tokens(expected_flags)
+    if applied_tokens != expected_tokens:
+        raise RuntimeError(
+            f"PPT-Master export flags mismatch: expected {list(expected_flags)}, "
+            f"got {applied_tokens}"
+        )

--- a/ResearchStudio-Reel/skills/paper2video/tests/test_focus_contract.py
+++ b/ResearchStudio-Reel/skills/paper2video/tests/test_focus_contract.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from focus_contract import normalize_video_focus  # noqa: E402
+
+
+class FocusContractTests(unittest.TestCase):
+    def test_all_pointer_spotlight_combinations_map_to_renderer_styles(self) -> None:
+        expected = {
+            ("cursor", "spotlight"): "spotlight_cursor",
+            ("cursor", "box"): "box_cursor",
+            ("cursor", "none"): "cursor",
+            ("laser", "spotlight"): "spotlight_laser",
+            ("laser", "box"): "box_laser",
+            ("laser", "none"): "laser",
+            ("none", "spotlight"): "spotlight",
+            ("none", "box"): "box",
+            ("none", "none"): "none",
+        }
+        for (pointer, spotlight), combined in expected.items():
+            with self.subTest(pointer=pointer, spotlight=spotlight):
+                self.assertEqual(
+                    normalize_video_focus(pointer, spotlight),
+                    (pointer, spotlight, combined),
+                )
+
+    def test_legacy_combined_value_is_still_accepted(self) -> None:
+        self.assertEqual(
+            normalize_video_focus(legacy_style="box_cursor"),
+            ("cursor", "box", "box_cursor"),
+        )
+
+    def test_invalid_values_fall_back_to_current_default(self) -> None:
+        self.assertEqual(
+            normalize_video_focus("wand", "blur"),
+            ("laser", "spotlight", "spotlight_laser"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ResearchStudio-Reel/skills/paper2video/tests/test_ppt_options_contract.py
+++ b/ResearchStudio-Reel/skills/paper2video/tests/test_ppt_options_contract.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from ppt_options_contract import (  # noqa: E402
+    PPT_MASTER_MODES,
+    PPT_MASTER_VISUAL_STYLES,
+    PPT_OPTIONS_PUBLIC_CATALOG,
+    PptOptionsValidationError,
+    export_flags_from_options,
+    fallback_resolved_ppt_options,
+    merge_resolved_ppt_options,
+    parse_json_object,
+    validate_resolved_ppt_options,
+)
+
+
+def requested(**overrides):
+    values = {
+        "duration": "5",
+        "ppt_page_count": "auto",
+        "ppt_mode": "auto",
+        "ppt_visual_style": "auto",
+        "ppt_delivery_purpose": "presentation",
+        "ppt_audience": "",
+        "ppt_color": "",
+        "ppt_typography": "",
+        "ppt_icons": "auto",
+        "ppt_formula_policy": "mixed",
+        "ppt_image_usage": ["auto"],
+    }
+    values.update(overrides)
+    return values
+
+
+def valid_resolution(**overrides):
+    values = {
+        "page_count": 10,
+        "mode": "narrative",
+        "visual_style": "editorial",
+        "delivery_purpose": "presentation",
+        "target_audience": "Machine learning researchers and engineers",
+        "color_direction": (
+            "Light editorial palette with background #F8FAFC and accent #2563EB"
+        ),
+        "typography_direction": "Aptos headings with Aptos body text",
+        "icon_library": "tabler-outline",
+        "formula_policy": "mixed",
+        "image_usage": ["provided", "placeholder"],
+        "image_ai_path": "not-used",
+    }
+    values.update(overrides)
+    return values
+
+
+class PptOptionContractTests(unittest.TestCase):
+    def test_public_catalog_is_the_source_of_backend_enums(self) -> None:
+        mode_ids = tuple(
+            option["id"]
+            for option in PPT_OPTIONS_PUBLIC_CATALOG["narrative_modes"]
+        )
+        style_ids = (
+            "auto",
+            *tuple(
+                option["id"]
+                for group in PPT_OPTIONS_PUBLIC_CATALOG["visual_style_groups"]
+                for option in group["options"]
+            ),
+        )
+        self.assertEqual(PPT_MASTER_MODES, mode_ids)
+        self.assertEqual(PPT_MASTER_VISUAL_STYLES, style_ids)
+        self.assertEqual(len(mode_ids), len(set(mode_ids)))
+        self.assertEqual(len(style_ids), len(set(style_ids)))
+
+    def test_invalid_invented_enum_values_are_rejected(self) -> None:
+        for key, value in (
+            ("mode", "flat"),
+            ("visual_style", "minimal-editorial"),
+        ):
+            payload = valid_resolution(**{key: value})
+            with self.subTest(key=key, value=value):
+                with self.assertRaises(PptOptionsValidationError):
+                    validate_resolved_ppt_options(
+                        payload,
+                        requested(),
+                        image_api_available=False,
+                    )
+
+    def test_explicit_user_values_cannot_be_replaced(self) -> None:
+        with self.assertRaises(PptOptionsValidationError):
+            validate_resolved_ppt_options(
+                valid_resolution(mode="narrative"),
+                requested(ppt_mode="instructional"),
+                image_api_available=False,
+            )
+
+    def test_valid_auto_resolution_is_locked_into_video_options(self) -> None:
+        original = requested()
+        resolved = validate_resolved_ppt_options(
+            valid_resolution(),
+            original,
+            image_api_available=False,
+        )
+        merged = merge_resolved_ppt_options(original, resolved)
+        self.assertEqual(merged["ppt_mode"], "narrative")
+        self.assertEqual(merged["ppt_visual_style"], "editorial")
+        self.assertEqual(merged["ppt_page_count"], "10")
+        self.assertEqual(merged["_ppt_user_request"]["ppt_color"], "")
+
+    def test_fallback_uses_only_catalog_values(self) -> None:
+        resolved = fallback_resolved_ppt_options(
+            requested(duration="8"),
+            image_api_available=False,
+        )
+        self.assertEqual(resolved["page_count"], 16)
+        self.assertIn(resolved["mode"], PPT_MASTER_MODES)
+        self.assertIn(resolved["visual_style"], PPT_MASTER_VISUAL_STYLES)
+        self.assertNotIn("ai", resolved["image_usage"])
+
+    def test_ai_path_matches_image_sources(self) -> None:
+        with self.assertRaises(PptOptionsValidationError):
+            validate_resolved_ppt_options(
+                valid_resolution(image_usage=["ai"], image_ai_path="not-used"),
+                requested(),
+                image_api_available=True,
+            )
+
+    def test_parser_requires_one_clean_json_object(self) -> None:
+        parsed = parse_json_object('```json\n{"mode": "narrative"}\n```')
+        self.assertEqual(parsed, {"mode": "narrative"})
+        with self.assertRaises(PptOptionsValidationError):
+            parse_json_object('{"mode": "narrative"} trailing prose')
+
+    def test_export_flags_preserve_grouping_and_optional_switches(self) -> None:
+        self.assertEqual(
+            export_flags_from_options(
+                {
+                    "ppt_transition": "wipe",
+                    "ppt_animation": "fade",
+                    "ppt_animation_trigger": "on-click",
+                    "ppt_native_objects": True,
+                    "ppt_strict_line_fidelity": True,
+                }
+            ),
+            [
+                "-t wipe",
+                "-a fade",
+                "--animation-trigger on-click",
+                "--native-objects",
+                "--no-merge",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ResearchStudio-Reel/skills/paper2video/tests/test_ppt_stage_validator.py
+++ b/ResearchStudio-Reel/skills/paper2video/tests/test_ppt_stage_validator.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from ppt_stage_validator import (  # noqa: E402
+    audit_descriptive_options,
+    audit_export_flags,
+)
+
+
+LOCK_TEXT = """\
+<!-- ppt-master-schema: spec-lock/v1 -->
+# Execution Lock
+
+## communication
+- audience: ML and AI researchers following foundation-model and embodied-agent work
+
+## colors
+- bg: #0B1120
+- primary: #38E1D6
+- accent: #7C5CFF
+- text: #C7D6EE
+
+## typography
+- font_family: Inter, "Helvetica Neue", Arial, sans-serif
+- title_family: Inter, "Helvetica Neue", Arial, sans-serif
+- body_family: Inter, "Helvetica Neue", Arial, sans-serif
+- body: 24
+- title: 46
+"""
+
+DESIGN_TEXT = """\
+# SIMA 2 Video Deck - Design Spec
+
+| Item | Value |
+| --- | --- |
+| Target Audience | Machine-learning and AI researchers, embodied-agent and RL practitioners following foundation-model work |
+
+## Color Scheme
+
+| Role | HEX |
+| --- | --- |
+| Background | #0B1120 |
+| Primary | #38E1D6 |
+| Accent | #7C5CFF |
+| Body text | #C7D6EE |
+
+## Typography System
+
+| Role | English |
+| --- | --- |
+| Title | Inter |
+| Body | Inter |
+"""
+
+AUTO_APPLIED = {
+    "target_audience": (
+        "Machine-learning and AI researchers following foundation-model "
+        "and embodied-agent work"
+    ),
+    "typography_direction": (
+        "Single clean sans (Inter) for titles and body, with JetBrains Mono labels"
+    ),
+    "color_direction": (
+        "Dark-tech palette: #0B1120 background, #38E1D6 primary, "
+        "#7C5CFF accent, #C7D6EE body text"
+    ),
+}
+
+
+class DescriptiveOptionValidatorTests(unittest.TestCase):
+    def test_official_spec_lock_v1_color_keys_are_supported(self) -> None:
+        audit_descriptive_options(AUTO_APPLIED, {}, LOCK_TEXT, DESIGN_TEXT)
+
+    def test_historical_long_color_keys_remain_supported(self) -> None:
+        legacy_lock = (
+            LOCK_TEXT
+            .replace("- bg:", "- background:")
+            .replace("- text:", "- body_text:")
+        )
+        audit_descriptive_options(AUTO_APPLIED, {}, legacy_lock, DESIGN_TEXT)
+
+    def test_generated_body_color_alias_remains_supported(self) -> None:
+        legacy_lock = LOCK_TEXT.replace("- text:", "- body:")
+        audit_descriptive_options(AUTO_APPLIED, {}, legacy_lock, DESIGN_TEXT)
+
+    def test_body_and_body_text_aliases_cannot_conflict(self) -> None:
+        conflicting_lock = LOCK_TEXT.replace(
+            "- text: #C7D6EE",
+            "- body: #C7D6EE\n- body_text: #FFFFFF",
+        )
+        with self.assertRaisesRegex(RuntimeError, "conflicting aliases for body_text"):
+            audit_descriptive_options(
+                AUTO_APPLIED,
+                {},
+                conflicting_lock,
+                DESIGN_TEXT,
+            )
+
+    def test_conflicting_color_aliases_are_rejected(self) -> None:
+        conflicting_lock = LOCK_TEXT.replace(
+            "- bg: #0B1120",
+            "- bg: #0B1120\n- background: #FFFFFF",
+        )
+        with self.assertRaisesRegex(RuntimeError, "conflicting aliases for background"):
+            audit_descriptive_options(
+                AUTO_APPLIED,
+                {},
+                conflicting_lock,
+                DESIGN_TEXT,
+            )
+
+    def test_missing_color_role_names_the_semantic_role(self) -> None:
+        missing_text_lock = LOCK_TEXT.replace("- text: #C7D6EE\n", "")
+        with self.assertRaisesRegex(RuntimeError, "body_text"):
+            audit_descriptive_options(
+                AUTO_APPLIED,
+                {},
+                missing_text_lock,
+                DESIGN_TEXT,
+            )
+
+    def test_real_auto_output_allows_equivalent_non_verbatim_audience(self) -> None:
+        audit_descriptive_options(AUTO_APPLIED, {}, LOCK_TEXT, DESIGN_TEXT)
+
+    def test_auto_audience_must_still_agree_with_execution_lock(self) -> None:
+        applied = {**AUTO_APPLIED, "target_audience": "Primary-school art teachers"}
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Auto target audience is inconsistent",
+        ):
+            audit_descriptive_options(applied, {}, LOCK_TEXT, DESIGN_TEXT)
+
+    def test_explicit_audience_cannot_be_ignored(self) -> None:
+        requested = "Undergraduate biology students"
+        applied = {**AUTO_APPLIED, "target_audience": requested}
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "did not record the requested target audience",
+        ):
+            audit_descriptive_options(
+                applied,
+                {"ppt_audience": requested},
+                LOCK_TEXT,
+                DESIGN_TEXT,
+            )
+
+    def test_explicit_typography_cannot_be_ignored(self) -> None:
+        requested = "Use Comic Sans for every text role"
+        applied = {**AUTO_APPLIED, "typography_direction": requested}
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "did not record the requested typography",
+        ):
+            audit_descriptive_options(
+                applied,
+                {"ppt_typography": requested},
+                LOCK_TEXT,
+                DESIGN_TEXT,
+            )
+
+    def test_explicit_color_cannot_be_ignored(self) -> None:
+        requested = "Use a warm coral and cream palette"
+        applied = {**AUTO_APPLIED, "color_direction": requested}
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "did not record the requested color",
+        ):
+            audit_descriptive_options(
+                applied,
+                {"ppt_color": requested},
+                LOCK_TEXT,
+                DESIGN_TEXT,
+            )
+
+
+class ExportFlagValidatorTests(unittest.TestCase):
+    def test_accepts_tokenized_production_receipt(self) -> None:
+        audit_export_flags(["-t", "fade", "-a", "none"], ["-t fade", "-a none"])
+
+    def test_accepts_grouped_receipt(self) -> None:
+        audit_export_flags(["-t fade", "-a none"], ["-t fade", "-a none"])
+
+    def test_rejects_an_option_that_was_not_applied(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "export flags mismatch"):
+            audit_export_flags(
+                ["-t", "none", "-a", "none"],
+                ["-t fade", "-a none"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ResearchStudio-Reel/skills/paper2video/tests/test_video_qa_gate.py
+++ b/ResearchStudio-Reel/skills/paper2video/tests/test_video_qa_gate.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from check_video_package import Finding, findings_pass_gate  # noqa: E402
+
+
+def finding(severity: str, code: str) -> Finding:
+    return Finding(severity=severity, code=code, message=code)
+
+
+class VideoQAGateTests(unittest.TestCase):
+    def test_audio_extra_files_remains_visible_but_passes_strict_gate(self) -> None:
+        findings = [finding("warning", "audio_extra_files")]
+        self.assertTrue(
+            findings_pass_gate(findings, fail_on_warning=True)
+        )
+        self.assertEqual(findings[0].severity, "warning")
+
+    def test_other_warning_still_fails_strict_or_fail_on_warning_gate(self) -> None:
+        self.assertFalse(
+            findings_pass_gate(
+                [finding("warning", "subtitle_duration_drift")],
+                fail_on_warning=True,
+            )
+        )
+
+    def test_audio_exception_does_not_hide_another_warning(self) -> None:
+        self.assertFalse(
+            findings_pass_gate(
+                [
+                    finding("warning", "audio_extra_files"),
+                    finding("warning", "frame_visuals_too_small"),
+                ],
+                fail_on_warning=True,
+            )
+        )
+
+    def test_warning_passes_when_warning_gate_is_disabled(self) -> None:
+        self.assertTrue(
+            findings_pass_gate(
+                [finding("warning", "subtitle_duration_drift")],
+                fail_on_warning=False,
+            )
+        )
+
+    def test_error_always_fails_even_when_warning_gate_is_disabled(self) -> None:
+        self.assertFalse(
+            findings_pass_gate(
+                [finding("error", "script_slide_count_mismatch")],
+                fail_on_warning=False,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- moves the Paper2Video option, focus, and PPT-stage validation contracts into the canonical Paper2Video Skill
- preserves compatibility for historical `body`/`body_text` color roles while requiring new projects to emit canonical keys
- keeps only the audio-extra-files warning non-blocking; all other Video QA warnings and errors remain gated
- narrows Reel QA to Reel integration responsibilities without changing Paper2Poster QA
- centralizes the Paper2Reel download contract in the canonical Skill
- adds explicit `materialized` and `on_demand` delivery modes: standalone Reel keeps four offline ZIPs by default, while Portal jobs publish only `assets/meta/reel_downloads.json`
- validates module isolation, the exact All union, unsafe/internal paths, stale archives, online endpoints, and `file://` behavior
- prevents nested ZIP growth and removes persistent ZIPs when a Portal bundle is republished in on-demand mode

## Why

Portal-specific runtime patches duplicated Skill behavior and allowed production drift. These changes restore one canonical implementation inside the corresponding Skills while preserving standalone and historical download behavior.

## Validation

- Paper2Video: 34 unit tests passed
- Paper2Reel: 19 unit tests passed; 1 loopback-socket test skipped by the local sandbox
- Web Portal coordinated branch: 108 tests passed
- Paper2Reel Skill structure validation passed
- Python compilation and both repositories' `git diff --check` passed

## Coordinated deployment

This PR is paired with `ai-nuts/researchstudio-web-portal` PR #1. Deployment order is strict: update and smoke-test this canonical Skill first, then update/restart Web. The Web branch also fail-fast checks the actual per-job builder capability before starting Poster, Video, or Blog work.
