### PR TITLE
fix(paper2assets): make SKILL.md description valid YAML for strict parsers

### DIFF
--- a/ResearchStudio-Reel/skills/paper2assets/SKILL.md
+++ b/ResearchStudio-Reel/skills/paper2assets/SKILL.md
@@ -1,6 +1,19 @@
 ---
 name: paper2assets
-description: Extract a research paper PDF into a structured set of poster-agnostic assets reusable by any downstream renderer (paper2poster, paper2blog, paper2audio, paper2video). Produces a `<outdir>/` containing the paper's full text (assets/meta/text.txt), per-figure captions (assets/meta/captions.json), cleaned figure rasters (assets/figures/*.png + assets/meta/figures.json manifest), paper metadata (assets/meta/metadata.json: title / authors / institutes / venue / paper_url / code_url), institute logos (assets/logos/*), URL QR codes (assets/qr/*), and a 9-section structured paper summary (assets/meta/paper_spec.md). The bundle follows the Output Contract layout (deliverables at top, everything else under `assets/`). Use when the user wants to extract paper content into reusable assets, OR as the mandatory upstream stage of any paper-rendering pipeline — e.g., "extract this paper", "build paper assets", "get the figures and spec from this PDF", "paper2assets".
+description: >-
+  Extract a research paper PDF into a structured set of poster-agnostic assets
+  reusable by any downstream renderer (paper2poster, paper2blog, paper2audio,
+  paper2video). Produces a `<outdir>/` containing the paper's full text
+  (assets/meta/text.txt), per-figure captions (assets/meta/captions.json),
+  cleaned figure rasters (assets/figures/*.png + assets/meta/figures.json
+  manifest), paper metadata (assets/meta/metadata.json: title / authors /
+  institutes / venue / paper_url / code_url), institute logos (assets/logos/*),
+  URL QR codes (assets/qr/*), and a 9-section structured paper summary
+  (assets/meta/paper_spec.md). The bundle follows the Output Contract layout
+  (deliverables at top, everything else under `assets/`). Use when the user
+  wants to extract paper content into reusable assets, OR as the mandatory
+  upstream stage of any paper-rendering pipeline — e.g., "extract this paper",
+  "build paper assets", "get the figures and spec from this PDF", "paper2assets".
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, AskUserQuestion, WebFetch, WebSearch
 ---
 


### PR DESCRIPTION
## Problem

The `description` field in `paper2assets/SKILL.md` is a single plain scalar containing `metadata.json: title / authors / ...`. The colon-space sequence is interpreted by strict YAML parsers as a nested mapping inside a compact mapping:

```
Nested mappings are not allowed in compact mappings at line 2, column 14
```

Claude Code and Codex tolerate this (lenient parsing), but tools that validate against the Agent Skills spec — such as Pi — refuse to load the skill.

## Fix

Convert `description` to a folded block scalar (`>`) with identical content. Colons inside a block scalar are literal, so `metadata.json: title / ...` no longer parses as a nested mapping.

## Impact

- No content change — the description text is byte-identical after folding (verified: 965 chars, word-for-word identical).
- Makes the skill load correctly on strict YAML / Agent Skills parsers while remaining compatible with Claude Code and Codex.
