### PR TITLE
Randomize Video Auto appearance and package offline Reel downloads

### DIFF
--- a/ResearchStudio-Reel/skills/paper2reel/SKILL.md
+++ b/ResearchStudio-Reel/skills/paper2reel/SKILL.md
@@ -182,8 +182,16 @@ Download delivery has two explicit modes:
   opening hides these online-only links.
 
 Both modes exclude `.claude/`, nested download directories, backups, and
-internal files. On-demand module entries are whitelisted and `all` is their
-deduplicated union. Use `on_demand` for Portal jobs and `materialized` for
+internal files. Poster, Video, and Blog keep their existing module-specific
+contents. New manifests mark `all_package_version: paper2reel.all.v2`; their
+All archive is instead a self-contained offline Reel containing `reel.html`,
+`content_alignment.json`, the Reel runtime under `assets/poster`,
+`assets/media`, `assets/slides`, `assets/blog`, `assets/ui`, and `assets/fonts`,
+plus the final Poster PDF/PPTX, Video MP4/PPTX, and EN/CN Blog DOCX files. It
+does not duplicate the root `poster.html` or `poster.png`, and it excludes
+build/cache trees and nested ZIPs. Historical manifests without
+`all_package_version` retain the original deduplicated-union behavior and
+remain downloadable. Use `on_demand` for Portal jobs and `materialized` for
 standalone offline bundles unless the caller explicitly chooses otherwise.
 
 ## Timeline-Backed Section Media

--- a/ResearchStudio-Reel/skills/paper2reel/scripts/build_poster_slides_view.py
+++ b/ResearchStudio-Reel/skills/paper2reel/scripts/build_poster_slides_view.py
@@ -22,9 +22,11 @@ from typing import Any
 
 from reel_downloads import (
     ARCHIVE_META,
+    DOWNLOAD_ALL_PACKAGE_VERSION,
     DOWNLOAD_MANIFEST_PATH,
     archive_links,
     build_download_manifest,
+    selected_all_package_files,
     selected_files,
     validate_download_manifest,
     write_download_manifest,
@@ -1392,7 +1394,10 @@ def build_downloads(
         if source is not None and source.is_dir()
     }
     resolved_sources = set(available.values())
-    manifest_root = next(iter(resolved_sources)) if len(resolved_sources) == 1 else outdir.resolve()
+    if download_mode == "materialized" or len(resolved_sources) != 1:
+        manifest_root = outdir.resolve()
+    else:
+        manifest_root = next(iter(resolved_sources))
     download_manifest = build_download_manifest(
         bundle_root=manifest_root,
         poster_source=available.get("poster"),
@@ -1420,8 +1425,20 @@ def build_downloads(
     downloads_dir = outdir / DOWNLOADS_DIR
     downloads: list[dict[str, str]] = []
     if available:
-        all_files: list[tuple[Path, Path]]
-        if len(resolved_sources) == 1:
+        if (
+            download_manifest.get("all_package_version")
+            == DOWNLOAD_ALL_PACKAGE_VERSION
+        ):
+            all_files = [
+                (path, relative)
+                for path, relative, _source in selected_all_package_files(
+                    outdir,
+                    poster_source=available.get("poster"),
+                    video_source=available.get("video"),
+                    blog_source=available.get("blog"),
+                )
+            ]
+        elif len(resolved_sources) == 1:
             source = next(iter(resolved_sources))
             union: dict[str, tuple[Path, Path]] = {}
             for module in available:
@@ -1665,6 +1682,16 @@ def main() -> int:
         1,
     )
     (outdir / "reel.html").write_text(html, encoding="utf-8")
+
+    # Rebuild after the two Reel root files exist. The bootstrap publisher
+    # rebuilds once more after timeline media is copied into the final bundle.
+    build_downloads(
+        outdir=outdir,
+        poster_final_dir=download_poster_dir,
+        blog_final_dir=download_blog_dir,
+        video_final_dir=download_video_dir,
+        download_mode=args.download_mode,
+    )
 
     print(f"[paper2reel] wrote {outdir / 'reel.html'}")
     print(f"[paper2reel] wrote {outdir / 'content_alignment.json'}")

--- a/ResearchStudio-Reel/skills/paper2reel/scripts/build_reel_from_paper.py
+++ b/ResearchStudio-Reel/skills/paper2reel/scripts/build_reel_from_paper.py
@@ -23,6 +23,7 @@ from typing import Any
 from reel_downloads import (
     DOWNLOAD_MANIFEST_PATH,
     build_download_manifest,
+    materialize_download_archives,
     validate_download_manifest,
     write_download_manifest,
 )
@@ -402,9 +403,10 @@ def sync_reel_into_bundle(
         copytree_replace(stage_assets / name, target_assets / name)
     target_downloads = target_assets / "downloads"
     if download_mode == "materialized":
+        # Preserve the three legacy module archives byte-for-byte. Only All
+        # depends on the final Reel runtime and is rebuilt below.
         copytree_replace(stage_assets / "downloads", target_downloads)
     elif target_downloads.exists():
-        # Reclaim historical ZIPs when publishing an on-demand Reel.
         shutil.rmtree(target_downloads)
 
     stage_slides = stage_assets / "slides"
@@ -419,31 +421,33 @@ def sync_reel_into_bundle(
     meta_dir = target_assets / "meta"
     meta_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(staging_dir / "manifest.json", meta_dir / "reel_manifest.json")
+    download_manifest = build_download_manifest(
+        bundle_root=target_dir,
+        poster_source=target_dir,
+        video_source=target_dir,
+        blog_source=target_dir,
+        delivery=download_mode,
+    )
+    issues = validate_download_manifest(
+        download_manifest,
+        bundle_root=target_dir,
+        require_sources=True,
+    )
+    if issues:
+        first = issues[0]
+        raise SystemExit(
+            f"Cannot publish {download_mode} Reel downloads: "
+            f"{first['code']}: {first['message']}"
+        )
+    write_download_manifest(target_dir / DOWNLOAD_MANIFEST_PATH, download_manifest)
     if download_mode == "materialized":
-        shutil.copy2(
-            staging_dir / DOWNLOAD_MANIFEST_PATH,
-            target_dir / DOWNLOAD_MANIFEST_PATH,
-        )
-    else:
-        download_manifest = build_download_manifest(
-            bundle_root=target_dir,
-            poster_source=target_dir,
-            video_source=target_dir,
-            blog_source=target_dir,
-            delivery="on_demand",
-        )
-        issues = validate_download_manifest(
+        materialize_download_archives(
             download_manifest,
             bundle_root=target_dir,
-            require_sources=True,
+            downloads_dir=target_downloads,
+            kinds=("all",),
+            clear_destination=False,
         )
-        if issues:
-            first = issues[0]
-            raise SystemExit(
-                "Cannot publish on-demand Reel downloads: "
-                f"{first['code']}: {first['message']}"
-            )
-        write_download_manifest(target_dir / DOWNLOAD_MANIFEST_PATH, download_manifest)
 
     manifest_path = target_dir / "manifest.json"
     manifest = load_json(manifest_path, {})

--- a/ResearchStudio-Reel/skills/paper2reel/scripts/reel_downloads.py
+++ b/ResearchStudio-Reel/skills/paper2reel/scripts/reel_downloads.py
@@ -9,12 +9,15 @@ the final-package checker use this module so path validation cannot drift.
 from __future__ import annotations
 
 import json
+import shutil
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable
 
 
 DOWNLOAD_SCHEMA_VERSION = "paper2reel.downloads.v1"
+DOWNLOAD_ALL_PACKAGE_VERSION = "paper2reel.all.v2"
 DOWNLOAD_MANIFEST_PATH = Path("assets/meta/reel_downloads.json")
 DOWNLOAD_DELIVERIES = {"materialized", "on_demand"}
 ARCHIVE_ORDER = ("all", "poster", "video", "blog")
@@ -43,6 +46,41 @@ MODULE_FILES: dict[str, dict[str, set[str]]] = {
         "files": {"blog_en.docx", "blog_zh.docx"},
         "directories": set(),
     },
+}
+ALL_PACKAGE_ROOT_FILES = {
+    "reel.html",
+    "content_alignment.json",
+    "poster.pdf",
+    "poster.pptx",
+    "video.mp4",
+    "video.pptx",
+    "blog_en.docx",
+    "blog_zh.docx",
+}
+ALL_PACKAGE_REQUIRED_FILES = set(ALL_PACKAGE_ROOT_FILES)
+ALL_PACKAGE_RUNTIME_DIRECTORIES = {
+    "assets/poster",
+    "assets/media",
+    "assets/slides",
+    "assets/blog",
+    "assets/ui",
+    "assets/fonts",
+}
+ALL_PACKAGE_EXCLUDED_PARTS = {
+    "_pptx_build",
+    "build",
+    "cache",
+    "caches",
+    "meta",
+    "previews",
+    "reports",
+    "temp",
+    "tmp",
+}
+ALL_PACKAGE_MODULE_FILES = {
+    "poster": {"poster.pdf", "poster.pptx"},
+    "video": {"video.mp4", "video.pptx"},
+    "blog": {"blog_en.docx", "blog_zh.docx"},
 }
 PROHIBITED_PARTS = {
     ".claude",
@@ -108,6 +146,26 @@ def matches_module(relative: Path | PurePosixPath, module: str) -> bool:
     )
 
 
+def matches_all_package(relative: Path | PurePosixPath) -> bool:
+    """Return whether a path belongs in the self-contained Download All ZIP."""
+    relative_posix = relative.as_posix()
+    if not is_safe_relative_posix(relative_posix):
+        return False
+    if relative.suffix.lower() == ".zip":
+        return False
+    lowered_parts = tuple(part.lower() for part in relative.parts)
+    if any(part.startswith(".") for part in lowered_parts):
+        return False
+    if set(lowered_parts) & ALL_PACKAGE_EXCLUDED_PARTS:
+        return False
+    if len(relative.parts) == 1:
+        return relative_posix in ALL_PACKAGE_ROOT_FILES
+    return any(
+        relative_posix.startswith(f"{directory}/")
+        for directory in ALL_PACKAGE_RUNTIME_DIRECTORIES
+    )
+
+
 def selected_files(
     source: Path,
     *,
@@ -128,6 +186,58 @@ def selected_files(
             continue
         selected.append((path, relative))
     return selected
+
+
+def selected_all_package_files(
+    bundle_root: Path,
+    *,
+    poster_source: Path | None,
+    video_source: Path | None,
+    blog_source: Path | None,
+) -> list[tuple[Path, Path, Path]]:
+    """Select one offline Reel plus the final user-facing module outputs.
+
+    Runtime files always come from ``bundle_root``. Final Poster, Video, and
+    Blog deliverables may come from separate source directories while a
+    materialized Reel is being staged. Archive names stay rooted at the Reel
+    package, and collisions prefer the already-published bundle copy.
+    """
+    bundle_root = bundle_root.resolve()
+    selected: dict[str, tuple[Path, Path, Path]] = {}
+
+    if bundle_root.is_dir():
+        for path in sorted(bundle_root.rglob("*")):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(bundle_root)
+            if matches_all_package(relative):
+                selected.setdefault(
+                    relative.as_posix().casefold(),
+                    (path, relative, bundle_root),
+                )
+
+    sources = {
+        "poster": poster_source,
+        "video": video_source,
+        "blog": blog_source,
+    }
+    for module in ("poster", "video", "blog"):
+        raw_source = sources[module]
+        if raw_source is None:
+            continue
+        source = Path(raw_source).resolve()
+        if not source.is_dir():
+            continue
+        for name in sorted(ALL_PACKAGE_MODULE_FILES[module]):
+            path = source / name
+            relative = Path(name)
+            if path.is_file():
+                selected.setdefault(
+                    relative.as_posix().casefold(),
+                    (path, relative, source),
+                )
+
+    return [selected[key] for key in sorted(selected)]
 
 
 def _bundle_path(path: Path, source: Path, bundle_root: Path, *, strict: bool) -> str:
@@ -201,7 +311,24 @@ def build_download_manifest(
         ]
 
     all_entries: dict[str, dict[str, Any]] = {}
-    if len(set(sources.values())) <= 1:
+    all_package_files = selected_all_package_files(
+        bundle_root,
+        poster_source=sources.get("poster"),
+        video_source=sources.get("video"),
+        blog_source=sources.get("blog"),
+    )
+    has_reel_runtime = {
+        relative.as_posix()
+        for _path, relative, _source in all_package_files
+    }.issuperset({"reel.html", "content_alignment.json"})
+    if has_reel_runtime:
+        for path, relative, source in all_package_files:
+            item = _entry(path, relative, source, bundle_root, strict=strict)
+            all_entries.setdefault(str(item["arcname"]), item)
+    elif len(set(sources.values())) <= 1:
+        # A temporary viewer staging directory may be created before reel.html
+        # exists. Preserve the historical union format until the final bundle
+        # is published and the manifest can be rebuilt as an offline Reel.
         for module in ("poster", "video", "blog"):
             for item in module_entries[module]:
                 all_entries.setdefault(str(item["arcname"]), dict(item))
@@ -225,12 +352,15 @@ def build_download_manifest(
             **ARCHIVE_META[kind],
             "files": entries_by_archive[kind],
         }
-    return {
+    payload = {
         "schema_version": DOWNLOAD_SCHEMA_VERSION,
         "delivery": delivery,
         "created_at": utc_now(),
         "archives": archives,
     }
+    if has_reel_runtime:
+        payload["all_package_version"] = DOWNLOAD_ALL_PACKAGE_VERSION
+    return payload
 
 
 def write_download_manifest(path: Path, payload: dict[str, Any]) -> None:
@@ -273,6 +403,16 @@ def validate_download_manifest(
                 "DOWNLOAD_MANIFEST_SCHEMA_INVALID",
                 f"schema_version must be {DOWNLOAD_SCHEMA_VERSION}.",
                 data={"actual": payload.get("schema_version")},
+            )
+        )
+    all_package_version = payload.get("all_package_version")
+    if all_package_version not in {None, DOWNLOAD_ALL_PACKAGE_VERSION}:
+        issues.append(
+            _issue(
+                "DOWNLOAD_ALL_PACKAGE_VERSION_INVALID",
+                f"all_package_version must be {DOWNLOAD_ALL_PACKAGE_VERSION} when present.",
+                path="all_package_version",
+                data={"actual": all_package_version},
             )
         )
     delivery = payload.get("delivery")
@@ -416,6 +556,18 @@ def validate_download_manifest(
                             data={"archive": kind, "path": source_path, "arcname": arcname},
                         )
                     )
+            if kind == "all" and all_package_version == DOWNLOAD_ALL_PACKAGE_VERSION:
+                if not matches_all_package(PurePosixPath(source_path)) or not matches_all_package(
+                    PurePosixPath(arcname)
+                ):
+                    issues.append(
+                        _issue(
+                            "DOWNLOAD_ALL_FILE_CLASSIFICATION_INVALID",
+                            "Download All may contain only the offline Reel runtime and final module deliverables.",
+                            path=item_path,
+                            data={"path": source_path, "arcname": arcname},
+                        )
+                    )
 
             if require_sources:
                 candidate = bundle_root / source_path
@@ -456,24 +608,124 @@ def validate_download_manifest(
             valid_entries.append((source_path, arcname, size))
         normalized[kind] = valid_entries
 
-    if delivery == "on_demand" and all(kind in normalized for kind in ARCHIVE_ORDER):
-        expected_all: dict[str, tuple[str, str, int]] = {}
-        for kind in ("poster", "video", "blog"):
-            for entry in normalized[kind]:
-                expected_all.setdefault(entry[1].casefold(), entry)
+    if all(kind in normalized for kind in ARCHIVE_ORDER):
         actual_all = {
             entry[1].casefold(): entry
             for entry in normalized["all"]
         }
-        if actual_all != expected_all:
-            issues.append(
-                _issue(
-                    "DOWNLOAD_ALL_UNION_INVALID",
-                    "The All archive must be the deduplicated union of Poster, Video, and Blog.",
-                    path="archives.all.files",
-                )
+        if all_package_version is None:
+            if delivery == "on_demand":
+                expected_all: dict[str, tuple[str, str, int]] = {}
+                for kind in ("poster", "video", "blog"):
+                    for entry in normalized[kind]:
+                        expected_all.setdefault(entry[1].casefold(), entry)
+                if actual_all != expected_all:
+                    issues.append(
+                        _issue(
+                            "DOWNLOAD_ALL_UNION_INVALID",
+                            "A historical All archive must be the deduplicated union of Poster, Video, and Blog.",
+                            path="archives.all.files",
+                        )
+                    )
+        elif all_package_version == DOWNLOAD_ALL_PACKAGE_VERSION:
+            missing = sorted(
+                name
+                for name in ALL_PACKAGE_REQUIRED_FILES
+                if name.casefold() not in actual_all
             )
+            if missing:
+                issues.append(
+                    _issue(
+                        "DOWNLOAD_ALL_REQUIRED_FILE_MISSING",
+                        "The self-contained Download All package is missing required Reel or module deliverables.",
+                        path="archives.all.files",
+                        data={"files": missing},
+                    )
+                )
+            if require_sources:
+                expected_all: dict[str, tuple[str, str, int]] = {}
+                for path, relative, source in selected_all_package_files(
+                    bundle_root,
+                    poster_source=bundle_root,
+                    video_source=bundle_root,
+                    blog_source=bundle_root,
+                ):
+                    item = _entry(
+                        path,
+                        relative,
+                        source,
+                        bundle_root,
+                        strict=True,
+                    )
+                    entry = (
+                        str(item["path"]),
+                        str(item["arcname"]),
+                        int(item["size"]),
+                    )
+                    expected_all.setdefault(entry[1].casefold(), entry)
+                if actual_all != expected_all:
+                    issues.append(
+                        _issue(
+                            "DOWNLOAD_ALL_PACKAGE_INVALID",
+                            "Download All must exactly match the self-contained Reel package selected from the final bundle.",
+                            path="archives.all.files",
+                        )
+                    )
     return issues
+
+
+def materialize_download_archives(
+    payload: dict[str, Any],
+    *,
+    bundle_root: Path,
+    downloads_dir: Path | None = None,
+    kinds: Iterable[str] = ARCHIVE_ORDER,
+    clear_destination: bool = True,
+) -> dict[str, Path]:
+    """Write selected manifest archives for standalone/materialized delivery."""
+    bundle_root = bundle_root.resolve()
+    if payload.get("delivery") != "materialized":
+        raise ValueError("materialized archives require delivery=materialized")
+    issues = validate_download_manifest(
+        payload,
+        bundle_root=bundle_root,
+        require_sources=True,
+    )
+    if issues:
+        first = issues[0]
+        raise ValueError(f"{first['code']}: {first['message']}")
+
+    selected_kinds = tuple(kinds)
+    unknown_kinds = sorted(set(selected_kinds) - set(ARCHIVE_ORDER))
+    if unknown_kinds:
+        raise ValueError(f"unknown download archives: {', '.join(unknown_kinds)}")
+
+    destination = (
+        Path(downloads_dir).resolve()
+        if downloads_dir is not None
+        else bundle_root / "assets" / "downloads"
+    )
+    if clear_destination and destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True, exist_ok=True)
+
+    written: dict[str, Path] = {}
+    for kind in selected_kinds:
+        archive_spec = payload["archives"][kind]
+        archive_path = destination / str(archive_spec["filename"])
+        with zipfile.ZipFile(
+            archive_path,
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+            allowZip64=True,
+        ) as archive:
+            for item in archive_spec["files"]:
+                archive.write(
+                    bundle_root / str(item["path"]),
+                    str(item["arcname"]),
+                )
+        written[kind] = archive_path
+    return written
 
 
 def read_download_manifest(bundle_root: Path) -> dict[str, Any]:

--- a/ResearchStudio-Reel/skills/paper2reel/tests/test_download_archives.py
+++ b/ResearchStudio-Reel/skills/paper2reel/tests/test_download_archives.py
@@ -55,6 +55,8 @@ class ReelDownloadBuilderTests(unittest.TestCase):
     def make_shared_bundle(self, root: Path) -> Path:
         bundle = root / "paper"
         files = {
+            "reel.html": b"<html>reel</html>",
+            "content_alignment.json": b"{}",
             "poster.html": b"poster",
             "poster.png": b"png",
             "poster.pdf": b"pdf",
@@ -71,6 +73,18 @@ class ReelDownloadBuilderTests(unittest.TestCase):
             "assets/logos/logo.png": b"logo",
             "assets/qr/code.png": b"qr",
             "assets/captions/video.vtt": b"WEBVTT",
+            "assets/poster/poster.html": b"<html>embedded poster</html>",
+            "assets/poster/figure.png": b"embedded-poster-figure",
+            "assets/poster/assets/_pptx_build/dom.json": b"build-only",
+            "assets/poster/assets/meta/poster_qa.json": b"{}",
+            "assets/media/video.mp4": b"runtime-video",
+            "assets/media/captions/video.vtt": b"WEBVTT",
+            "assets/media/clips/intro.mp4": b"clip",
+            "assets/media/cache/render.bin": b"cache",
+            "assets/media/nested.zip": b"nested-zip",
+            "assets/slides/slide_01.png": b"slide",
+            "assets/blog/figures/figure_01.png": b"blog-figure",
+            "assets/ui/reel-wordmark.png": b"wordmark",
             "assets/downloads/old.zip": b"old-download",
             ".claude/scratch.txt": b"internal",
         }
@@ -135,12 +149,41 @@ class ReelDownloadBuilderTests(unittest.TestCase):
             self.assertNotIn("video.mp4", names["poster_final.zip"])
             self.assertNotIn("blog_en.docx", names["poster_final.zip"])
 
-            expected_all = (
-                names["poster_final.zip"]
-                | names["video_final.zip"]
-                | names["blog_final.zip"]
-            )
+            expected_all = {
+                "reel.html",
+                "content_alignment.json",
+                "poster.pdf",
+                "poster.pptx",
+                "video.mp4",
+                "video.pptx",
+                "blog_en.docx",
+                "blog_zh.docx",
+                "assets/poster/poster.html",
+                "assets/poster/figure.png",
+                "assets/media/video.mp4",
+                "assets/media/captions/video.vtt",
+                "assets/media/clips/intro.mp4",
+                "assets/slides/slide_01.png",
+                "assets/blog/figures/figure_01.png",
+                "assets/ui/reel-wordmark.png",
+                "assets/fonts/font.woff2",
+            }
             self.assertEqual(expected_all, names["all_final.zip"])
+            self.assertEqual(
+                reel_downloads.DOWNLOAD_ALL_PACKAGE_VERSION,
+                download_manifest["all_package_version"],
+            )
+            self.assertNotIn("poster.html", names["all_final.zip"])
+            self.assertNotIn("poster.png", names["all_final.zip"])
+            self.assertFalse(
+                any("_pptx_build" in name for name in names["all_final.zip"])
+            )
+            self.assertFalse(
+                any("cache" in name.lower() for name in names["all_final.zip"])
+            )
+            self.assertFalse(
+                any(name.lower().endswith(".zip") for name in names["all_final.zip"])
+            )
             for archive_names in names.values():
                 self.assertFalse(
                     any(name.startswith("assets/downloads/") for name in archive_names)
@@ -246,6 +289,10 @@ class ReelDownloadBuilderTests(unittest.TestCase):
             manifest = read_json(bundle / reel_downloads.DOWNLOAD_MANIFEST_PATH)
             self.assertEqual("on_demand", manifest["delivery"])
             self.assertEqual(
+                reel_downloads.DOWNLOAD_ALL_PACKAGE_VERSION,
+                manifest["all_package_version"],
+            )
+            self.assertEqual(
                 set(reel_downloads.ARCHIVE_ORDER),
                 set(manifest["archives"]),
             )
@@ -270,6 +317,12 @@ class ReelDownloadBuilderTests(unittest.TestCase):
             self.assertIn("assets/figures/figure1.png", poster_files)
             self.assertNotIn("video.mp4", poster_files)
             all_files = manifest["archives"]["all"]["files"]
+            all_names = {item["arcname"] for item in all_files}
+            self.assertIn("reel.html", all_names)
+            self.assertIn("assets/poster/poster.html", all_names)
+            self.assertIn("assets/media/video.mp4", all_names)
+            self.assertNotIn("poster.html", all_names)
+            self.assertNotIn("poster.png", all_names)
             self.assertEqual(
                 len(all_files),
                 len({item["arcname"] for item in all_files}),
@@ -286,6 +339,67 @@ class ReelDownloadBuilderTests(unittest.TestCase):
                     require_sources=True,
                 ),
             )
+
+    def test_historical_union_manifest_remains_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = self.make_shared_bundle(Path(tmp))
+            manifest = reel_downloads.build_download_manifest(
+                bundle_root=bundle,
+                poster_source=bundle,
+                video_source=bundle,
+                blog_source=bundle,
+                delivery="on_demand",
+            )
+            manifest.pop("all_package_version")
+            union: dict[str, dict] = {}
+            for kind in ("poster", "video", "blog"):
+                for item in manifest["archives"][kind]["files"]:
+                    union.setdefault(item["arcname"], dict(item))
+            manifest["archives"]["all"]["files"] = [
+                union[name] for name in sorted(union)
+            ]
+
+            self.assertEqual(
+                [],
+                reel_downloads.validate_download_manifest(
+                    manifest,
+                    bundle_root=bundle,
+                    require_sources=True,
+                ),
+            )
+            _filename, files = reel_downloads.archive_files(
+                manifest,
+                "all",
+                bundle_root=bundle,
+            )
+            self.assertIn("poster.html", {arcname for _path, arcname in files})
+            self.assertNotIn("reel.html", {arcname for _path, arcname in files})
+
+    def test_v2_all_manifest_rejects_missing_runtime_member(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = self.make_shared_bundle(Path(tmp))
+            manifest = reel_downloads.build_download_manifest(
+                bundle_root=bundle,
+                poster_source=bundle,
+                video_source=bundle,
+                blog_source=bundle,
+                delivery="on_demand",
+            )
+            manifest["archives"]["all"]["files"] = [
+                item
+                for item in manifest["archives"]["all"]["files"]
+                if item["arcname"] != "reel.html"
+            ]
+            codes = {
+                issue["code"]
+                for issue in reel_downloads.validate_download_manifest(
+                    manifest,
+                    bundle_root=bundle,
+                    require_sources=True,
+                )
+            }
+            self.assertIn("DOWNLOAD_ALL_REQUIRED_FILE_MISSING", codes)
+            self.assertIn("DOWNLOAD_ALL_PACKAGE_INVALID", codes)
 
 
 class ReelDownloadCheckerTests(unittest.TestCase):
@@ -557,6 +671,100 @@ class ReelPublishTests(unittest.TestCase):
                 reel_files["downloads_manifest"],
             )
             self.assertNotIn("downloads_dir", reel_files)
+
+    def test_materialized_publish_rebuilds_complete_all_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            target = ReelDownloadBuilderTests().make_shared_bundle(base)
+            staging = base / "staging"
+            write(staging / "reel.html", b"<html>new reel</html>")
+            write(staging / "content_alignment.json", b"{}")
+            write(
+                staging / "manifest.json",
+                json.dumps(
+                    {
+                        "schema_version": "paper2reel.v1",
+                        "local_open": {"supported": True},
+                    }
+                ).encode(),
+            )
+            write(staging / "assets" / "poster" / "poster.html", b"embedded")
+            write(staging / "assets" / "media" / "video.mp4", b"runtime")
+            write(
+                staging / "assets" / "media" / "captions" / "video.vtt",
+                b"WEBVTT",
+            )
+            write(staging / "assets" / "media" / "cache" / "render.bin", b"cache")
+            write(staging / "assets" / "slides" / "slide_01.png", b"slide")
+            write(staging / "assets" / "blog" / "figures" / "figure.png", b"figure")
+            write(staging / "assets" / "ui" / "reel-wordmark.png", b"wordmark")
+            builder.build_downloads(
+                outdir=staging,
+                poster_final_dir=target,
+                video_final_dir=target,
+                blog_final_dir=target,
+                download_mode="materialized",
+            )
+            staged_downloads = staging / "assets" / "downloads"
+            module_bytes_before = {
+                name: (staged_downloads / name).read_bytes()
+                for name in (
+                    "poster_final.zip",
+                    "video_final.zip",
+                    "blog_final.zip",
+                )
+            }
+            for module, name in (
+                ("poster", "poster_final.zip"),
+                ("video", "video_final.zip"),
+                ("blog", "blog_final.zip"),
+            ):
+                legacy_members = {
+                    relative.as_posix()
+                    for _path, relative in reel_downloads.selected_files(
+                        target,
+                        module=module,
+                    )
+                }
+                self.assertEqual(legacy_members, zip_names(staged_downloads / name))
+
+            bootstrap.sync_reel_into_bundle(
+                staging,
+                target,
+                download_mode="materialized",
+            )
+
+            manifest = read_json(target / reel_downloads.DOWNLOAD_MANIFEST_PATH)
+            self.assertEqual(
+                reel_downloads.DOWNLOAD_ALL_PACKAGE_VERSION,
+                manifest["all_package_version"],
+            )
+            self.assertEqual(
+                [],
+                reel_downloads.validate_download_manifest(
+                    manifest,
+                    bundle_root=target,
+                    require_sources=True,
+                ),
+            )
+            downloads = target / "assets" / "downloads"
+            all_names = zip_names(downloads / "all_final.zip")
+            self.assertEqual(
+                {item["arcname"] for item in manifest["archives"]["all"]["files"]},
+                all_names,
+            )
+            self.assertIn("reel.html", all_names)
+            self.assertIn("assets/media/video.mp4", all_names)
+            self.assertNotIn("poster.html", all_names)
+            self.assertNotIn("poster.png", all_names)
+            self.assertNotIn("assets/media/cache/render.bin", all_names)
+
+            for name, expected_bytes in module_bytes_before.items():
+                self.assertEqual(expected_bytes, (downloads / name).read_bytes())
+            poster_names = zip_names(downloads / "poster_final.zip")
+            self.assertIn("poster.html", poster_names)
+            self.assertIn("poster.png", poster_names)
+            self.assertIn("assets/_pptx_build/dom.json", poster_names)
 
 
 class ReelCopyNormalizationTests(unittest.TestCase):

--- a/ResearchStudio-Reel/skills/paper2video/SKILL.md
+++ b/ResearchStudio-Reel/skills/paper2video/SKILL.md
@@ -232,6 +232,15 @@ default high-quality route is `ppt-master`.
 - If a machine dependency is missing, record the concrete missing dependency and
   stop. Do not silently degrade to a different slide-generation method.
 
+Resolve PPT options once before invoking ppt-master. Content-related Auto values
+(page count, narrative mode, audience, images, and formulas) remain paper-aware
+model decisions. Appearance Auto values (visual style, color direction, and
+typography direction) are selected from the canonical finite pools by
+`resolve_auto_ppt_appearance()` using the immutable task token. Persist that
+appearance receipt with the validated resolution in `resolved_options.json`,
+then reuse the merged locked configuration for every downstream step and retry.
+Never rerandomize an in-progress task. Explicit appearance values are unchanged.
+
 When using `ppt-master`, prepare title-slide utility assets before invoking the
 deck workflow:
 

--- a/ResearchStudio-Reel/skills/paper2video/scripts/ppt_options_contract.py
+++ b/ResearchStudio-Reel/skills/paper2video/scripts/ppt_options_contract.py
@@ -1,19 +1,22 @@
 """Canonical Paper2Video and PPT-Master option contract.
 
-Descriptive fields such as audience, color, and typography remain bounded
-strings because PPT-Master intentionally generates those from the paper;
-every enumerable field is closed over the catalog below.
+Audience remains a bounded paper-aware string. Color and typography are bounded
+strings so explicit user directions and backend-selected Auto values share the
+same schema; every enumerable field is closed over the catalog below.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
+import random
 import re
 from collections.abc import Mapping
 
 
 CATALOG_VERSION = "paper2video-ppt-options.v1"
+PPT_APPEARANCE_CATALOG_VERSION = "paper2video-ppt-appearance.v1"
 
 PPT_OPTIONS_PUBLIC_CATALOG = {
     "narrative_modes": (
@@ -174,6 +177,23 @@ _CONCRETE_IMAGE_USAGE = tuple(
     value for value in PPT_MASTER_IMAGE_USAGE if value != "auto"
 )
 
+PPT_AUTO_COLOR_DIRECTIONS = (
+    "Light blue palette: background #F8FAFC, text #0F172A, accent #2563EB",
+    "Dark cyan palette: background #0B1120, text #F8FAFC, accent #22D3EE",
+    "Warm coral palette: background #FFF7ED, text #431407, accent #F97316",
+    "Forest palette: background #F0FDF4, text #14532D, accent #10B981",
+    "Burgundy palette: background #FFF1F2, text #4C0519, accent #BE123C",
+    "Violet palette: background #FAF5FF, text #3B0764, accent #7C3AED",
+)
+
+PPT_AUTO_TYPOGRAPHY_DIRECTIONS = (
+    "Aptos Display headings with Aptos body text and strong size contrast",
+    "Arial headings and body text with Courier New for code and data labels",
+    "Georgia headings with Arial body text and restrained editorial contrast",
+    "Trebuchet MS headings with Arial body text and generous spacing",
+    "Arial Black headings with Arial body text and compact bold labels",
+)
+
 PPT_RESOLVED_SCHEMA = {
     "$id": CATALOG_VERSION,
     "type": "object",
@@ -247,6 +267,69 @@ def prompt_catalog() -> dict:
         "image_usage": list(_CONCRETE_IMAGE_USAGE),
         "image_ai_path": ["api", "not-used"],
     }
+
+
+def _is_auto_appearance_text(value: object) -> bool:
+    return str(value or "").strip().lower() in {"", "auto", "random"}
+
+
+def resolve_auto_ppt_appearance(
+    requested: Mapping[str, object],
+    *,
+    task_token: str,
+) -> tuple[dict, dict]:
+    """Resolve appearance-only Auto values before the content resolver runs.
+
+    The task token seeds a local PRNG, so separate jobs receive varied appearance
+    systems while every retry of one job receives the same system.  Narrative,
+    audience, page-count, image, and formula Auto values stay untouched for the
+    paper-aware resolver.  Explicit appearance values always win.
+    """
+    token = str(task_token or "").strip()
+    if not token:
+        raise PptOptionsValidationError(
+            "task_token is required to lock randomized PPT appearance"
+        )
+
+    seed_digest = hashlib.sha256(
+        f"{PPT_APPEARANCE_CATALOG_VERSION}\0{token}".encode("utf-8")
+    ).hexdigest()
+    rng = random.Random(int(seed_digest, 16))
+    resolver_request = dict(requested)
+    randomized_fields: list[str] = []
+
+    requested_style = str(requested.get("ppt_visual_style") or "auto").strip()
+    if requested_style.lower() in {"", "auto", "random"}:
+        visual_style = rng.choice(_CONCRETE_VISUAL_STYLES)
+        resolver_request["ppt_visual_style"] = visual_style
+        randomized_fields.append("visual_style")
+    else:
+        if requested_style not in _CONCRETE_VISUAL_STYLES:
+            raise PptOptionsValidationError(
+                f"ppt_visual_style must be one of {list(PPT_MASTER_VISUAL_STYLES)}"
+            )
+        visual_style = requested_style
+
+    selected = {"visual_style": visual_style}
+    for request_key, resolved_key, choices in (
+        ("ppt_color", "color_direction", PPT_AUTO_COLOR_DIRECTIONS),
+        ("ppt_typography", "typography_direction", PPT_AUTO_TYPOGRAPHY_DIRECTIONS),
+    ):
+        value = requested.get(request_key)
+        if _is_auto_appearance_text(value):
+            value = rng.choice(choices)
+            resolver_request[request_key] = value
+            randomized_fields.append(resolved_key)
+        selected[resolved_key] = str(value)
+
+    appearance_lock = {
+        "catalog_version": PPT_APPEARANCE_CATALOG_VERSION,
+        "strategy": "task-seeded-random",
+        "seed_fingerprint": seed_digest[:16],
+        "randomized_fields": randomized_fields,
+        "selected": selected,
+    }
+    return resolver_request, appearance_lock
 
 
 def export_flags_from_options(opts: Mapping[str, object]) -> list[str]:
@@ -544,16 +627,19 @@ def resolution_prompt(
         "image_api_available": image_api_available,
     }
     return (
-        "Resolve Paper2Video's PPT-Master Auto options before any deck generation. "
+        "Resolve Paper2Video's content-related PPT-Master Auto options before any "
+        "deck generation. Appearance Auto values (visual_style, color_direction, "
+        "and typography_direction) have already been selected and locked by the "
+        "backend; preserve those values exactly. "
         "This is a read-only planning call: inspect the PDF as needed, do not modify "
         "files, and return exactly one JSON object with no Markdown or prose.\n"
         "Every enumerable value MUST be copied verbatim from canonical_catalog. "
         "Never create, combine, alias, or rename an enum id. Preserve every explicit "
-        "non-Auto request exactly. Descriptive audience/color/typography fields may "
-        "be paper-specific strings; an Auto color_direction must include at least "
-        "two concrete #RRGGBB values and typography_direction must name its primary "
-        "font. Set image_ai_path to `api` exactly when image_usage contains `ai`, "
-        "otherwise `not-used`.\n"
+        "non-Auto request exactly. Target audience may be a paper-specific string. "
+        "The locked color_direction must retain its concrete #RRGGBB values, and the "
+        "locked typography_direction must retain its named primary font. Set "
+        "image_ai_path to `api` exactly when image_usage contains `ai`, otherwise "
+        "`not-used`.\n"
         f"{retry}"
         f"canonical_catalog = {json.dumps(prompt_catalog(), ensure_ascii=False)}\n"
         f"json_schema = {json.dumps(PPT_RESOLVED_SCHEMA, ensure_ascii=False)}\n"

--- a/ResearchStudio-Reel/skills/paper2video/tests/test_ppt_options_contract.py
+++ b/ResearchStudio-Reel/skills/paper2video/tests/test_ppt_options_contract.py
@@ -9,6 +9,8 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from ppt_options_contract import (  # noqa: E402
+    PPT_AUTO_COLOR_DIRECTIONS,
+    PPT_AUTO_TYPOGRAPHY_DIRECTIONS,
     PPT_MASTER_MODES,
     PPT_MASTER_VISUAL_STYLES,
     PPT_OPTIONS_PUBLIC_CATALOG,
@@ -17,6 +19,7 @@ from ppt_options_contract import (  # noqa: E402
     fallback_resolved_ppt_options,
     merge_resolved_ppt_options,
     parse_json_object,
+    resolve_auto_ppt_appearance,
     validate_resolved_ppt_options,
 )
 
@@ -112,6 +115,93 @@ class PptOptionContractTests(unittest.TestCase):
         self.assertEqual(merged["ppt_visual_style"], "editorial")
         self.assertEqual(merged["ppt_page_count"], "10")
         self.assertEqual(merged["_ppt_user_request"]["ppt_color"], "")
+
+    def test_auto_appearance_is_varied_once_then_locked(self) -> None:
+        original = requested()
+        first, first_lock = resolve_auto_ppt_appearance(
+            original,
+            task_token="job-123",
+        )
+        retry, retry_lock = resolve_auto_ppt_appearance(
+            original,
+            task_token="job-123",
+        )
+
+        self.assertEqual(first, retry)
+        self.assertEqual(first_lock, retry_lock)
+        self.assertNotEqual(first["ppt_visual_style"], "auto")
+        self.assertIn(first["ppt_color"], PPT_AUTO_COLOR_DIRECTIONS)
+        self.assertIn(
+            first["ppt_typography"],
+            PPT_AUTO_TYPOGRAPHY_DIRECTIONS,
+        )
+        self.assertEqual(first["ppt_mode"], "auto")
+        self.assertEqual(first["ppt_page_count"], "auto")
+        self.assertEqual(first["ppt_audience"], "")
+        self.assertEqual(first["ppt_icons"], "auto")
+        self.assertEqual(first["ppt_image_usage"], ["auto"])
+        self.assertEqual(
+            first_lock["randomized_fields"],
+            ["visual_style", "color_direction", "typography_direction"],
+        )
+        fallback = fallback_resolved_ppt_options(
+            first,
+            image_api_available=False,
+        )
+        self.assertEqual(fallback["visual_style"], first["ppt_visual_style"])
+        self.assertEqual(fallback["color_direction"], first["ppt_color"])
+        self.assertEqual(fallback["typography_direction"], first["ppt_typography"])
+
+    def test_auto_appearance_varies_between_task_tokens(self) -> None:
+        resolved = [
+            resolve_auto_ppt_appearance(requested(), task_token=f"job-{index}")[0]
+            for index in range(40)
+        ]
+        self.assertGreater(len({item["ppt_visual_style"] for item in resolved}), 1)
+        self.assertGreater(len({item["ppt_color"] for item in resolved}), 1)
+        self.assertGreater(len({item["ppt_typography"] for item in resolved}), 1)
+
+    def test_explicit_appearance_is_preserved(self) -> None:
+        original = requested(
+            ppt_visual_style="blueprint",
+            ppt_color="User palette #112233 with accent #445566",
+            ppt_typography="User supplied Arial typography",
+        )
+        resolved, lock = resolve_auto_ppt_appearance(
+            original,
+            task_token="job-explicit",
+        )
+
+        self.assertEqual(resolved, original)
+        self.assertEqual(lock["randomized_fields"], [])
+        self.assertEqual(
+            lock["selected"],
+            {
+                "visual_style": "blueprint",
+                "color_direction": "User palette #112233 with accent #445566",
+                "typography_direction": "User supplied Arial typography",
+            },
+        )
+
+    def test_model_cannot_replace_backend_locked_appearance(self) -> None:
+        locked, _ = resolve_auto_ppt_appearance(
+            requested(),
+            task_token="job-locked",
+        )
+        with self.assertRaises(PptOptionsValidationError):
+            validate_resolved_ppt_options(
+                valid_resolution(
+                    visual_style=(
+                        "editorial"
+                        if locked["ppt_visual_style"] != "editorial"
+                        else "blueprint"
+                    ),
+                    color_direction=locked["ppt_color"],
+                    typography_direction=locked["ppt_typography"],
+                ),
+                locked,
+                image_api_available=False,
+            )
 
     def test_fallback_uses_only_catalog_values(self) -> None:
         resolved = fallback_resolved_ppt_options(


### PR DESCRIPTION
## What changed

- Resolve Paper2Video appearance-only Auto values (visual style, color direction, typography direction) from finite PPT-safe pools using a task-token seed.
- Keep content-related Auto values paper-aware, preserve explicit appearance choices, and lock the resolved appearance for every retry and downstream step.
- Change Paper2Reel Download All to a self-contained offline Reel package containing `reel.html`, alignment data, runtime assets, and final module deliverables.
- Exclude root `poster.html`, root `poster.png`, build/cache/meta/temp artifacts, and nested ZIP files from Download All.
- Preserve the existing Poster, Video, and Blog archive contents; on-demand delivery still creates no persistent ZIP files.
- Keep unversioned historical union manifests valid.

## Why

The previous Portal-side implementation never reached the canonical Skills, so Auto appearance remained paper-recommended and Download All stayed a union of the three module archives. This moves both contracts into their owning Skills and makes retries and historical downloads deterministic and compatible.

## Validation

- Paper2Video: 38 tests passed.
- Paper2Reel: 22 tests passed; 1 loopback-socket test skipped by sandbox policy.
- Python compile checks and `git diff --check` passed.
- Portal integration smoke tests accepted the v2 manifest, streamed the expected ZIP without materializing it, retained historical-manifest compatibility, and persisted the locked appearance receipt.
