### PR TITLE
docs: News entry for the user-query pipeline change

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ The skills run on [Claude Code](https://docs.claude.com/en/docs/claude-code/over
 
 ## News 🔥🔥🔥
 
-- [**2026-07-08**] **[ResearchStudio-Reel](ResearchStudio-Reel/) is released** — the *post-paper* half: turn a finished paper PDF into the artifacts a publication needs — a print-ready poster, a narrated walkthrough video, a bilingual blog post, and an interactive reel viewer.
-- [**2026-07-03**] **[ResearchStudio-Idea](ResearchStudio-Idea/) is released** — the *pre-paper* half: turn an under-specified research direction into a reviewer-defensible, implementable idea, grounded in an empirical taxonomy induced from a large-scale corpus of ICLR / ICML / NeurIPS submissions.
+- [**2026-08-13**] `feature` **[IdeaSpark](ResearchStudio-Idea/) keeps the whole user query** — the user query is persisted verbatim and read by every phase that reasons about intent; papers named in it without a link are resolved and deep-read; and a stated solution direction reaches idea selection, which must record whether it followed or departed from that direction, and why.
+- [**2026-07-08**] `release` **[ResearchStudio-Reel](ResearchStudio-Reel/) is released** — the *post-paper* half: turn a finished paper PDF into the artifacts a publication needs — a print-ready poster, a narrated walkthrough video, a bilingual blog post, and an interactive reel viewer.
+- [**2026-07-03**] `release` **[ResearchStudio-Idea](ResearchStudio-Idea/) is released** — the *pre-paper* half: turn an under-specified research direction into a reviewer-defensible, implementable idea, grounded in an empirical taxonomy induced from a large-scale corpus of ICLR / ICML / NeurIPS submissions.
 
 ## Quick Start
 


### PR DESCRIPTION
Adds a News entry for the change merged in #35, and tags the two existing entries `release` so all three share one shape: `[date]` `type` `**[product](path) what happened**` — description.

The entry states what the pipeline does now; the reasoning and the measurements stay in the code and its tests, not on the front page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)