### PR TITLE
Fix Paper2Video per-element animation narration handoff

### DIFF
--- a/ResearchStudio-Reel/skills/paper2video/SKILL.md
+++ b/ResearchStudio-Reel/skills/paper2video/SKILL.md
@@ -17,7 +17,7 @@ paper.pdf
   -> assets/meta/paper_spec.md + assets/meta/narration.json
   -> ppt_options_contract.py resolve-ppt-trigger          (ONE trigger decision)
   -> installed ppt-master skill                          (full workflow, receives the trigger)
-  -> installed pptx2video skill / CLI `pptx2video render` (full workflow, receives the trigger)
+  -> installed pptx2video skill / CLI `bootstrap` then `render` (full workflow, receives the trigger)
   -> ppt_stage_validator.py audit-final-pptx-trigger      (proves the handoff held)
   -> video.mp4, video_no_subtitles.mp4, video.pptx
 ```
@@ -288,16 +288,16 @@ If the deck should carry no entrance animation at all (`-a none`, ppt-master's
 own default), the `--animation-trigger` flag is irrelevant and may be omitted;
 the resolved value only matters once `-a` requests an actual entrance effect.
 Leave speaker notes enabled (ppt-master's default; do not pass `--no-notes`)
-even though Step 4 does not rely on ppt-master's raw Notes text as the
-narration source -- see the note on notes format below.
+so Step 4 can replace its raw Notes with pptx2video's canonical per-element
+protocol -- see the note on notes format below.
 
 **ppt-master Notes are not pptx2video's Notes protocol.** ppt-master's
 `markdown_to_plain_text()` writes plain presenter-note paragraphs, not
 pptx2video's canonical `## [handle] semantic` block grammar. pptx2video treats
 ordinary presenter notes as absent narration and falls back to a generic
-per-shape handle. Do not assume the raw ppt-master PPTX is narration-ready;
-Step 4 supplies narration explicitly via `--script-json` instead of relying on
-ppt-master's Notes text.
+per-shape handle. Do not render an animated raw ppt-master PPTX directly.
+Step 4 first bootstraps the page-level narration into handle-addressed Notes
+and Alt Text.
 
 Before invoking ppt-master, prepare title-slide utility assets when a
 `paper2assets` package exists:
@@ -320,7 +320,7 @@ placeholders.
 Confirm the export produced a PPTX at `<project_path>/exports/<name>.pptx`
 before continuing to Step 4.
 
-## Step 4: Prepare narration for pptx2video
+## Step 4: Prepare narration and bootstrap the editable protocol
 
 Build a `script.json` from the shared `narration.json` so pptx2video's
 narration authority is explicit and does not depend on ppt-master's raw Notes
@@ -337,7 +337,7 @@ text:
 
 `assets/meta/narration.json` from paper2assets already has this
 `{"id", "heading", "text"}` shape; it can be used directly as the
-`--script-json` input in Step 5 provided its section count matches the PPTX
+`bootstrap --script-json` input provided its section count matches the PPTX
 slide count. The number of sections in this file must equal the number of
 slides in the deck exported in Step 3, in the same order; pptx2video rejects a
 section-count mismatch. When ppt-master's page-count resolution produced a
@@ -347,22 +347,36 @@ or edit the `script.json` copy so its section count and order match the
 delivered PPTX exactly. Do not truncate or duplicate sections to force a
 match.
 
-Passing this same file as `--ids-from-script` in Step 5 also fixes each
-slide's internal `section_id` to this file's `sections[*].id` order, so
-pptx2video's own section-id validation is satisfied automatically; do not
-build a separate id-mapping file.
+Bootstrap the ordinary animated deck once. This divides each slide's
+page-level narration across its animation targets and writes canonical
+handle-addressed Notes and Alt Text:
+
+```bash
+PPTX2VIDEO_WORK=$(mktemp -d)
+PPTX2VIDEO_SOURCE="$PPTX2VIDEO_WORK/video-protocol-source.pptx"
+PPTX2VIDEO_TMP="$PPTX2VIDEO_WORK/video-bundle"
+python3 -m pptx2video bootstrap \
+  "<project_path>/exports/<name>.pptx" \
+  --script-json "$VIDEO_AUDIO/script.json" \
+  --output "$PPTX2VIDEO_SOURCE"
+```
+
+Treat a non-zero bootstrap exit as blocking. Do not replace
+`$PPTX2VIDEO_SOURCE` with the raw ppt-master export in Step 5.
 
 ## Step 5: Render through pptx2video, passing the same resolved trigger
 
-Render into a fresh output directory; it must not already exist.
+Render the bootstrapped PPTX into the fresh output directory. Pass the
+page-level script only as `--ids-from-script`: this preserves the per-element
+narration written in Step 4 while fixing each slide's internal `section_id`.
+Do not use `--script-json` for this render; it would put the entire slide
+transcript on the first animation element while clearing the others.
 
 ```bash
-PPTX2VIDEO_TMP=$(mktemp -d)/video-bundle
 python3 -m pptx2video render \
-  "<project_path>/exports/<name>.pptx" \
+  "$PPTX2VIDEO_SOURCE" \
   "$PPTX2VIDEO_TMP" \
   --resolution 1080p \
-  --script-json "$VIDEO_AUDIO/script.json" \
   --ids-from-script "$VIDEO_AUDIO/script.json" \
   --animation-order-policy animation-pane \
   --click-group-policy <pptx2video_click_group_policy from Step 2>
@@ -507,7 +521,7 @@ The generic render runtime is not owned or vendored by this skill. Install
   (PATH, `--no-qa` not existing, click-group-policy defaults) that make an
   almost-right invocation silently diverge from the protocol.
 - `references/script_json_schema.md` - the `script.json` schema Step 4
-  builds and Step 5 passes as `--script-json` / `--ids-from-script`,
+  passes to `bootstrap` and Step 5 passes only as `--ids-from-script`,
   including the handle-level `elements` form and TTS text gotchas.
 - `references/ppt_trigger_handoff.md` - deep dive on the four-concept model,
   the native OOXML mechanics behind it, and the failure modes this skill's

--- a/ResearchStudio-Reel/skills/paper2video/references/pptx2video.md
+++ b/ResearchStudio-Reel/skills/paper2video/references/pptx2video.md
@@ -29,14 +29,21 @@ print `pptx2video 0.5.x`. Every command in this file and in `SKILL.md` uses
 `python3 -m pptx2video`, never the bare `pptx2video` binary, for exactly this
 reason.
 
-## The render command Step 5 uses
+## The bootstrap and render commands Steps 4-5 use
 
 ```bash
-python3 -m pptx2video render \
+PPTX2VIDEO_WORK=$(mktemp -d)
+PPTX2VIDEO_SOURCE="$PPTX2VIDEO_WORK/video-protocol-source.pptx"
+PPTX2VIDEO_TMP="$PPTX2VIDEO_WORK/video-bundle"
+python3 -m pptx2video bootstrap \
   "<project_path>/exports/<name>.pptx" \
+  --script-json "$VIDEO_AUDIO/script.json" \
+  --output "$PPTX2VIDEO_SOURCE"
+
+python3 -m pptx2video render \
+  "$PPTX2VIDEO_SOURCE" \
   "$PPTX2VIDEO_TMP" \
   --resolution 1080p \
-  --script-json "$VIDEO_AUDIO/script.json" \
   --ids-from-script "$VIDEO_AUDIO/script.json" \
   --animation-order-policy animation-pane \
   --click-group-policy <pptx2video_click_group_policy from Step 2>
@@ -65,17 +72,19 @@ the CLI refuses to write into an existing path.
   and print a decision report path instead of rendering. `animation-pane`
   confirms up front "trust the deck's own Animation Pane order," so a real
   conflict is resolved deterministically instead of stalling the run.
-- **`--script-json PATH`.** Supplies section-level (or handle-level) narration
-  text as the authority, overriding whatever the PPTX's own Notes/Alt Text
-  carry. Required so pptx2video's narration does not silently depend on
-  ppt-master's plain-paragraph Notes (see
-  `references/ppt_trigger_handoff.md` and `references/script_json_schema.md`
-  for why that matters).
+- **`bootstrap --script-json PATH`.** Supplies page-level narration while
+  converting ppt-master's ordinary animated deck into canonical per-element
+  Notes and Alt Text. Run this once before rendering.
+- **`render --script-json PATH`.** Replaces the PPTX's narration authority.
+  Do not pass a page-level script after bootstrap: `apply_user_script()` puts
+  the whole slide transcript on the first block and clears the other blocks.
+  Use this render flag only for an explicitly handle-addressed
+  `sections[*].elements` override.
 - **`--ids-from-script PATH`.** Fixes each slide's `section_id` to this file's
-  `sections[*].id`, in order. Pass the same file used for `--script-json`
-  (paper2video's Step 4 builds exactly one file for both flags). This makes
-  pptx2video's own section-count/section-id validation pass automatically;
-  do not hand-build a separate id-mapping file.
+  `sections[*].id`, in order without replacing block narration. Pass the same
+  file used by bootstrap. This makes pptx2video's own
+  section-count/section-id validation pass automatically; do not hand-build a
+  separate id-mapping file.
 - **`--resolution {720p,1080p,1440p,4k}`, default `1080p`.** Pass `1080p`
   explicitly for a predictable, documented default; do not silently rely on
   whatever the installed CLI version happens to default to.
@@ -140,16 +149,17 @@ SVG dependencies (Playwright plus a system or bundled Chromium). Fix whatever
 `pptx2video render` synthesizes all narration audio itself, automatically,
 using Edge TTS (`generate_edge_audio.py`, default voice
 `en-US-AriaNeural`). Paper2Video does not pre-synthesize any MP3 and does not
-pass a `--voice` flag by default; `--script-json`'s `text` is spoken content,
-not a file of pre-rendered audio. See `references/script_json_schema.md` for
-the exact schema `--script-json` and `--ids-from-script` both read.
+pass a `--voice` flag by default. Bootstrap distributes the page-level
+`script.json` text into the PPTX protocol; render then speaks that preserved
+per-element protocol. See `references/script_json_schema.md` for the exact
+schema.
 
 ## Advanced authoring surface
 
 For direct manual edits to an already-rendered deck (handle-level Notes/Alt
-Text markers, `--baseline-pptx` re-renders, `pptx2video bootstrap`), use the
-installed `/pptx2video` skill directly and read its own
+Text markers or `--baseline-pptx` re-renders), use the installed
+`/pptx2video` skill directly and read its own
 `references/cli.md` and `references/editable_pptx.md`. Those flows are
-outside this skill's one supported route (paper -> ppt-master -> `render`);
-this skill's Step 5 command above is the only render invocation this skill's
-protocol issues.
+outside this skill's one supported route (paper -> ppt-master -> `bootstrap`
+-> `render`); this skill's Step 5 command above is the only render invocation
+this skill's protocol issues.

--- a/ResearchStudio-Reel/skills/paper2video/references/script_json_schema.md
+++ b/ResearchStudio-Reel/skills/paper2video/references/script_json_schema.md
@@ -1,11 +1,10 @@
 # script.json - schema, authority, and gotchas
 
 `script.json` is the narration authority Step 4 of `SKILL.md` builds from the
-shared `assets/meta/narration.json`, and it is what Step 5 passes as both
-`--script-json` and `--ids-from-script` to `python3 -m pptx2video render`.
-This file describes exactly what pptx2video reads from it
-(`apply_user_script()` in the installed `pptx2video` package), not a
-narration format this skill invents on its own.
+shared `assets/meta/narration.json`. Step 4 passes it to `pptx2video
+bootstrap`; Step 5 passes it to `pptx2video render` only as
+`--ids-from-script`. This preserves the handle-addressed narration embedded by
+bootstrap instead of applying a second page-level override.
 
 ## Minimal shape (section-level narration)
 
@@ -32,12 +31,10 @@ count (see "Section count and order must match the PPTX" below).
   carry over legacy OpenAI-TTS-style `voice: "alloy"` fields from an older
   version of this document; they have no effect on the render.
 - **`sections[*].id` (required, string, one per PPTX slide, in slide order).**
-  Must equal that slide's `section_id` exactly, or pptx2video raises. Passing
-  the same file as both `--ids-from-script` and `--script-json` (as Step 5
-  does) makes this automatic: `--ids-from-script` assigns each slide's
-  `section_id` from this file's `id` list first, then `--script-json`'s own
-  id check compares against the id it just assigned, so the two can never
-  disagree. Do not build a separate id-mapping file for this.
+  Must equal that slide's `section_id` exactly, or pptx2video raises. Pass this
+  file as `--ids-from-script` during render so pptx2video assigns each slide's
+  `section_id` from the same list bootstrap consumed. Do not build a separate
+  id-mapping file for this.
 - **`sections[*].heading`.** Cosmetic; used only in the assembled report
   metadata. Not spoken.
 - **`sections[*].text`.** The spoken narration for the whole slide. Plain
@@ -45,7 +42,10 @@ count (see "Section count and order must match the PPTX" below).
   bullets) or literal code, since Edge TTS reads that syntax literally rather
   than rendering it, and speaking a code block aloud is rarely useful.
   Ending a section with sentence-final punctuation gives the TTS engine a
-  natural prosodic drop instead of a flat trail-off.
+  natural prosodic drop instead of a flat trail-off. Bootstrap distributes
+  this text across native animation targets. Never pass this page-level shape
+  to `render --script-json` after bootstrap: that override assigns all text to
+  the first block and clears the remaining blocks.
 - **`sections[*].elements` (optional, replaces `text` for that section when
   present).** For precise per-shape timing, address individual top-level
   shapes by their stable handle instead of narrating the whole slide as one
@@ -77,6 +77,11 @@ count (see "Section count and order must match the PPTX" below).
   user-supplied script; native entrance/exit animation timing comes from the
   PPTX's own `p:timing` tree (see `references/ppt_trigger_handoff.md`), not
   from a script marker.
+
+  This handle-level form is the only safe form for an intentional later
+  `render --script-json` override on an animated deck. The normal animated
+  Paper2Video path does not need that override because bootstrap already
+  persisted the per-element text.
 
 ## Section count and order must match the PPTX
 


### PR DESCRIPTION
## Summary

- bootstrap animated PPTX narration into canonical per-element Notes/Alt Text before rendering
- render the bootstrapped PPTX with `--ids-from-script` only, preserving each animation element's narration
- document why page-level `render --script-json` must not overwrite the canonical animation protocol

## Root cause

Paper2Video passed a page-level script to `pptx2video render --script-json`. On animated slides, pptx2video assigns that entire slide transcript to the first block and clears the remaining blocks.

## Validation

- skill validation passes
- `git diff --check` passes
- reproduced against the reported deck: bootstrap produced 36/36 narrated effects, and the IDs-only render preparation preserved 36/36 (the old path reduced this to 12/36)
- only 3 Paper2Video skill/documentation files changed; no test files included