### PR TITLE
Fix Paper2Assets per-figure source fallback

### DIFF
--- a/ResearchStudio-Reel/skills/paper2assets/SKILL.md
+++ b/ResearchStudio-Reel/skills/paper2assets/SKILL.md
@@ -48,7 +48,7 @@ Deliverables reference assets with **root-relative** `src` paths -- `assets/figu
    paper.pdf  (+ arXiv id / provided image links)
      │
      ▼  FIGURES — priority: source_figures.py (arXiv source / provided links) → clean assets/figures/*.png + figures.json
-     │           └─ fallback only: extract_pdf.py crops from the rendered PDF
+     │           └─ per-figure fallback: extract_pdf.py crops only unresolved/composite figures from the rendered PDF
      ▼  scripts/extract_pdf.py   → assets/meta/{text.txt, captions.json} (+ figures.json only on the crop fallback; use --no-figures on the source path)
      │
      ▼  Step 3 (model-driven)    → assets/meta/metadata.json
@@ -166,13 +166,14 @@ Writes:
    (downloads `arxiv.org/e-print/<id>`, parses the `.tex` figure order + captions, rasterizes each graphic).
 3. **Backup (ONLY if 1 & 2 don't apply, or `source_figures.py` exits non-zero):** the PDF crop path below — full `extract_pdf.py` (with figures) **+ Step 5 `crop_figure.py`**.
 
-**If `source_figures.py` succeeded (exit 0):** run `extract_pdf.py <pdf> --outdir <outdir> --no-figures` (text.txt + captions.json ONLY) and **SKIP Step 5 (`crop_figure.py`) entirely** — the source graphics are already clean. **Otherwise** run the full `extract_pdf.py <pdf> --outdir <outdir>` (with figures) and do Step 5.
+**If `source_figures.py` succeeded (exit 0):** run `extract_pdf.py <pdf> --outdir <outdir> --no-figures`. It always writes text/captions; when `source_figures.py` left any `source: "pdf-crop-pending"` records, it also aligns their TeX captions to explicit printed `Figure N` labels and fills **only those records** from the rendered PDF. Then run Step 5 only for records whose final `source` is `"pdf-crop"`; skip original source graphics. If there are no such records, skip Step 5 entirely. **Otherwise** run the full `extract_pdf.py <pdf> --outdir <outdir>` (with figures) and do Step 5 for every extracted figure.
 
-`source_figures.py` fails closed on a TeX figure environment containing more
-than one `\\includegraphics`. Selecting only the first child would bind a
-composite caption to an incomplete raster. Its non-zero exit deliberately
-routes the whole paper through the PDF crop fallback, which preserves the
-rendered composite.
+`source_figures.py` never selects only the first child of a multi-file TeX
+figure. It writes that one figure as `pdf-crop-pending` while preserving clean
+arXiv source assets for the other figures. `extract_pdf.py --no-figures`
+replaces the pending record only after a unique TeX-caption → printed
+`Figure N` alignment and an exact label join. Ambiguous or missing mappings
+fail closed instead of falling back to positional order.
 
 **Appendix figures — skipped by DEFAULT.** Process **main-body figures only**. From `text.txt`, find where the appendix / supplementary material begins (the first `Appendix` / `Supplementary` heading, or `A.` / `B.` / `S1`… content after `References`) and note its `\f`-delimited page. **Drop every figure on or after that page** — delete the PNGs from `figures/` and their rows from `figures.json` *before* Step 5, so neither the cleaning loop nor any downstream renderer sees them. **Override only when the user explicitly asks** — e.g. "include the appendix figures" or naming a specific supplementary figure.
 
@@ -259,18 +260,18 @@ Section-by-section guidance:
 
 `Audio script` subfields are full-sentence spoken paragraphs (3–6 sentences each) suitable for TTS. They are part of the spec because audio narration of *any* downstream rendering should be derivable from this single source.
 
-### Step 5 — Clean ALL figure images (mandatory on the crop path — SKIPPED when source figures were used)
+### Step 5 — Clean every PDF-crop figure (original source figures are skipped)
 
-> **Skip this entire step** if Step 2 sourced the ORIGINAL figures via `source_figures.py` (arXiv source bundle or provided image links) — those graphics are already clean. Step 5 runs ONLY on the crop-path fallback (figures cropped from the rendered PDF).
+> Build the worklist from `figures.json`: process every record with `"source": "pdf-crop"` and no record with `"source": "original"`. In a hybrid bundle this may be only one composite figure; in a full crop fallback it is every figure. Skip the entire step only when the worklist is empty.
 
 Step 2 produces raw figure rasters that often carry:
 - A 1–10 px **chrome residue** at the top edge (the bottom of a page rule line / banner / running title that the extractor's column-aware boundary couldn't perfectly avoid).
 - A **baked-in caption strip** at the bottom (rare — `extract_pdf.py` already clamps to `cap_full.y0 - 1`, but a few papers have caption text fused into the figure raster).
 - A uniform **white margin** of arbitrary thickness around the cleaned content (a side effect of the 50 px symmetric pad in Step 2 + caption-clamped tight tops).
 
-Downstream renderers should receive **cleaned** figures, not raw extracts, so we run the deterministic cleanup pipeline on every figure here — independent of which figures any downstream actually picks. Cost is sub-second per figure × 3 commands × N figures = negligible. **Skip this entire step when the figures were pre-supplied** (Step 2's "already supplied?" branch): original source graphics carry none of the chrome / caption-strip / margin defects below.
+Downstream renderers should receive **cleaned PDF crops**, so run the deterministic cleanup pipeline on every `source: "pdf-crop"` record — independent of which figures a downstream renderer picks. Cost is sub-second per crop × 3 commands × N figures. Original source graphics carry none of the chrome / caption-strip / margin defects below and are skipped individually.
 
-**For each `figures/<file>.png`, run 5a → 5b → 5c in this exact order:**
+**For each PDF-crop record's `figures/<file>.png`, run 5a → 5b → 5c in this exact order:**
 
 **5a. `top-check` — strip top chrome residue.**
 
@@ -298,7 +299,7 @@ Strips border rows/cols that are 100% near-white, keeping a `--pad 4` margin. Sa
 
 All three modes write `figures/_debug/<file>.png.bak` (one-shot, never clobbered on re-runs) and update `figures.json` width/height. The top-level `figures/` directory keeps only the in-progress clean PNG — backups and other debug artifacts live in the hidden `_debug/` subdir so downstream consumers see a clean listing.
 
-**5d. Visual AI cropping review (mandatory, runs on every figure).** The deterministic chain in 5a-5c handles uniform white margins, the chrome-residue pattern at the top edge, and the baked-in caption-strip pattern at the bottom edge. It does NOT handle:
+**5d. Visual AI cropping review (mandatory for every PDF-crop figure).** The deterministic chain in 5a-5c handles uniform white margins, the chrome-residue pattern at the top edge, and the baked-in caption-strip pattern at the bottom edge. It does NOT handle:
 
 - **Surrounding column body text leaked into the bbox** — when `extract_pdf.py`'s figure-region detection over-reaches into the paper's prose (a vertical strip of column text running alongside the figure, or a few lines of body paragraph above the figure). This is the most common defect, and it's *invisible* to autotrim/decaption: that text isn't a uniform white margin and isn't a thin caption sliver — it's *real ink* that paints similarly to figure content.
 - **Caption text not caught by `decaption`'s thin-strip pattern** — captions that are tightly butted against the figure body, or captions that span 4+ lines (decaption refuses on caption blocks taller than ~15% of figure height to avoid amputating real figure content).
@@ -555,16 +556,16 @@ paper2assets owns this responsibility because:
 
    **If the visual recheck reveals a structurally impossible crop** (e.g. the figure's y-axis labels share an x-range with a body-text column, so any rectangle that includes the labels also includes the body text), accept the best rectangular crop — the trade-off here is "lose axis labels" vs "include some body text"; the lesser evil depends on which is more visually offensive for downstream renderers. Note the residue in a brief `"note"` field on the figure's entry in `figures.json` so downstream is aware.
 
-**Why this step is mandatory and runs on every figure, not just on picked ones:** paper2assets is the single owner of figure cleanup. Downstream renderers shouldn't re-discover surrounding-column-text or baked-in caption artifacts that the upstream stage left in. The cost (one `blocks` call + 1–3 `mark`/Read iterations + 1 `box` per figure, ~7–20 figures per paper) is paid once here instead of N times across renderers.
+**Why this step is mandatory for every PDF-crop figure, not just picked ones:** paper2assets is the single owner of figure cleanup. Downstream renderers shouldn't re-discover surrounding-column-text or baked-in caption artifacts that the upstream stage left in. Original arXiv/source graphics are already clean and stay untouched.
 
 The `inspect` mode is helpful for quickly probing a figure's outer dimensions and pure-white border before deciding a bbox:
 ```bash
 python ~/.claude/skills/paper2assets/scripts/crop_figure.py inspect <outdir>/assets/figures/<file>.png
 ```
 
-### Step 5e — Final autotrim pass (mandatory, runs on every figure)
+### Step 5e — Final autotrim pass (mandatory for every PDF-crop figure)
 
-**For each `figures/<file>.png`, after 5d has committed its box crop, run autotrim one more time:**
+**For each PDF-crop record's `figures/<file>.png`, after 5d has committed its box crop, run autotrim one more time:**
 
 ```bash
 python ~/.claude/skills/paper2assets/scripts/crop_figure.py autotrim <outdir>/assets/figures/<file>.png
@@ -723,7 +724,7 @@ scripts/
 
 ## Key rules
 
-- **Step 5 runs on every figure, not just suspected ones.** Cost is trivial; missing chrome / trapped margins / surrounding paper text downstream is expensive.
+- **Step 5 runs on every `source: "pdf-crop"` figure, not just suspected ones; it never rewrites `source: "original"` assets.** Cost is trivial; missing chrome / trapped margins / surrounding paper text downstream is expensive.
 - **Step 5 ordering is non-negotiable.** top-check → decaption → autotrim → visual AI review (5d) → final autotrim mop-up (5e). 5d sits in the middle because the deterministic chain in 5a-5c handles the easy patterns first; 5d catches what the patterns can't (column body text leakage, asymmetric noise, captions outside decaption's thin-strip pattern). 5e closes the loop by re-running the cheap autotrim after 5d's visually-judged bbox commits — visual judgment leaves pixel-level whitespace residues even when the bbox looks tight, and 5e is the safe deterministic mop-up that ensures saved PNG dimensions match figure content extent.
 - **Main caption out, sub-captions in.** The paper's "Figure N: …" caption is already in `captions.json` as structured text — if you see that line at the bottom of a figure raster, CUT IT in 5d. **Panel sub-captions** like "(a) Pipeline overview" / "(b) Loss curves" stay — they label the sub-panels and are part of the figure's visual content; cutting them strips the figure of its own labels. Rule of thumb at the bottom edge: 1–3 short prose rows starting with "Figure N:" → CUT; short "(a)/(b)/(c) <label>" rows pinned right under each sub-panel → KEEP.
 - **Surrounding column body text never lives inside the figure raster either.** A vertical strip of paper prose alongside the figure, or a few lines of body paragraph above/below — all noise. 5d's per-edge check catches them; act on what you can describe in words.

--- a/ResearchStudio-Reel/skills/paper2assets/scripts/extract_pdf.py
+++ b/ResearchStudio-Reel/skills/paper2assets/scripts/extract_pdf.py
@@ -20,7 +20,7 @@ diagram, headline results plot) and skipping decorative or equation-as-image jun
 Captions are the cheapest, most reliable signal of what a figure actually shows, so
 we extract them alongside the images and let the model match figures to captions.
 """
-import argparse, json, re, subprocess, sys
+import argparse, json, re, shutil, subprocess, sys, tempfile
 from urllib.parse import urlparse
 from pathlib import Path
 
@@ -774,6 +774,157 @@ def extract_figures_pymupdf(pdf: Path, figdir: Path, text: str) -> list[dict]:
     return manifest
 
 
+def _canonical_figure_label(value: object) -> str:
+    """Normalize a printed Figure/Fig. label for exact manifest joins."""
+    match = re.fullmatch(r"\s*(?:figure|fig\.?)\s+(\d+)\s*", str(value or ""), re.I)
+    return f"Figure {int(match.group(1))}" if match else ""
+
+
+def fill_pending_pdf_crops(pdf: Path, outdir: Path, text: str) -> int:
+    """Replace only source records explicitly deferred to the PDF crop path.
+
+    TeX captions are first aligned to printed PDF captions by
+    ``sync_figure_captions``.  This function then joins on that explicit
+    ``Figure N`` label; it never assumes that list positions still match after
+    an unresolved source graphic.  Any missing, duplicate, or unaligned label
+    fails closed instead of attaching the wrong crop.
+    """
+    manifest_path = layout.meta_file(outdir, "figures")
+    try:
+        figures = json.loads(manifest_path.read_text())
+    except Exception as exc:
+        raise RuntimeError("source figures manifest is missing or invalid") from exc
+    if not isinstance(figures, list) or not figures:
+        raise RuntimeError("source figures manifest must be a non-empty list")
+
+    pending = [
+        (index, figure)
+        for index, figure in enumerate(figures)
+        if isinstance(figure, dict) and figure.get("source") == "pdf-crop-pending"
+    ]
+
+    claimed_labels: dict[str, int] = {}
+    for index, figure in enumerate(figures):
+        if not isinstance(figure, dict):
+            raise RuntimeError(f"source figures manifest record {index} is invalid")
+        if figure.get("source") == "pdf-crop-pending":
+            continue
+        file_value = str(figure.get("file") or "")
+        file_path = Path(file_value)
+        if not file_value or file_path.is_absolute() or not (outdir / file_path).is_file():
+            raise RuntimeError(f"source figure record {index} has no valid bundle-relative raster")
+        alignment = figure.get("caption_alignment") or {}
+        if pending and alignment.get("status") != "aligned":
+            raise RuntimeError(
+                f"hybrid source figure record {index} did not align uniquely to a printed Figure label"
+            )
+        label = _canonical_figure_label(figure.get("caption_label"))
+        if alignment.get("status") == "aligned" and label:
+            if label in claimed_labels:
+                raise RuntimeError(f"duplicate aligned source figure label: {label}")
+            claimed_labels[label] = index
+
+    if not pending:
+        return 0
+
+    requested: dict[str, tuple[int, dict]] = {}
+    for index, figure in pending:
+        alignment = figure.get("caption_alignment") or {}
+        label = _canonical_figure_label(figure.get("caption_label"))
+        if alignment.get("status") != "aligned" or not label:
+            source_identity = figure.get("source_label") or f"source order {figure.get('source_order', '?')}"
+            raise RuntimeError(
+                f"cannot safely map PDF fallback for {source_identity}: "
+                "TeX caption did not align uniquely to a printed Figure label"
+            )
+        if label in requested:
+            raise RuntimeError(f"duplicate pending PDF fallback label: {label}")
+        if label in claimed_labels:
+            raise RuntimeError(f"pending PDF fallback label already belongs to a source raster: {label}")
+        requested[label] = (index, figure)
+
+    with tempfile.TemporaryDirectory(prefix="paper2assets-pdf-fallback-") as td:
+        temp_figdir = Path(td) / "figures"
+        crops = extract_figures_pymupdf(pdf, temp_figdir, text)
+        crops_by_label: dict[str, dict] = {}
+        duplicate_crop_labels: set[str] = set()
+        for crop in crops:
+            label = _canonical_figure_label(crop.get("caption_label"))
+            if not label:
+                continue
+            if label in crops_by_label:
+                duplicate_crop_labels.add(label)
+            else:
+                crops_by_label[label] = crop
+
+        missing = sorted(label for label in requested if label not in crops_by_label)
+        ambiguous = sorted(label for label in requested if label in duplicate_crop_labels)
+        if missing or ambiguous:
+            details = []
+            if missing:
+                details.append("missing " + ", ".join(missing))
+            if ambiguous:
+                details.append("duplicate " + ", ".join(ambiguous))
+            raise RuntimeError(
+                "selective PDF fallback could not make an exact Figure-label join: "
+                + "; ".join(details)
+            )
+
+        # Validate every selected raster before mutating the canonical bundle.
+        selected: list[tuple[str, int, dict, dict, Path]] = []
+        for label, (index, pending_record) in requested.items():
+            crop = crops_by_label[label]
+            source_path = temp_figdir / Path(str(crop.get("file") or "")).name
+            if not source_path.is_file():
+                raise RuntimeError(f"selective PDF fallback raster is missing for {label}")
+            selected.append((label, index, pending_record, crop, source_path))
+
+        final_figdir = layout.figures_dir(outdir, create=True)
+        for label, index, pending_record, crop, source_path in selected:
+            target = final_figdir / source_path.name
+            shutil.copy2(source_path, target)
+
+            # Use the PDF crop's physical geometry while retaining the exact
+            # TeX identity/caption that caused this one-record fallback.
+            merged = dict(crop)
+            merged["file"] = f"{layout.FIGURES}/{target.name}"
+            merged["original_label"] = label
+            merged["caption_label"] = label
+            merged["caption"] = pending_record.get("source_caption") or crop.get("caption", "")
+            candidates = list(pending_record.get("caption_candidates") or [])
+            pdf_candidate = {
+                "label": label,
+                "text": str(crop.get("caption") or ""),
+                "source": "pdf-text",
+            }
+            if pdf_candidate not in candidates:
+                candidates.append(pdf_candidate)
+            merged["caption_candidates"] = candidates
+            for key in (
+                "source_label", "source_caption", "source_order",
+                "fallback_reason", "caption_alignment",
+            ):
+                if key in pending_record:
+                    merged[key] = pending_record[key]
+            merged["source"] = "pdf-crop"
+            figures[index] = merged
+
+    temp_manifest: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=manifest_path.parent,
+            prefix=".figures-", suffix=".json.tmp", delete=False,
+        ) as handle:
+            json.dump(figures, handle, indent=2, ensure_ascii=False)
+            handle.write("\n")
+            temp_manifest = Path(handle.name)
+        temp_manifest.replace(manifest_path)
+    finally:
+        if temp_manifest is not None:
+            temp_manifest.unlink(missing_ok=True)
+    return len(pending)
+
+
 def parse_metadata(text: str) -> dict:
     """Best-effort extraction of cover-page metadata from the first ~2 pages.
 
@@ -907,8 +1058,8 @@ def main():
     ap.add_argument("pdf")
     ap.add_argument("--outdir", required=True)
     ap.add_argument("--no-figures", action="store_true",
-                    help="skip figure extraction (write text.txt + captions.json only). "
-                         "Use when source_figures.py already supplied the original figures.")
+                    help="skip full figure extraction (write text.txt + captions.json, then "
+                         "fill only any pdf-crop-pending records left by source_figures.py).")
     args = ap.parse_args()
 
     pdf = Path(args.pdf).resolve()
@@ -962,7 +1113,15 @@ def main():
                 print(f"  backfilled {aligned} source figure caption(s) -> figures.json")
         except Exception as exc:
             print(f"  warning: source figure caption backfill failed: {exc}", file=sys.stderr)
-        print("Skipping figure extraction (--no-figures; original figures supplied by source_figures.py).")
+        try:
+            filled = fill_pending_pdf_crops(pdf, outdir, text)
+        except RuntimeError as exc:
+            print(f"  selective PDF fallback failed: {exc}", file=sys.stderr)
+            raise SystemExit(5) from exc
+        if filled:
+            print(f"  selectively filled {filled} deferred figure(s) from PDF crop")
+        else:
+            print("Skipping figure extraction (--no-figures; no deferred figures remain).")
         return
 
     print("Extracting figures...")

--- a/ResearchStudio-Reel/skills/paper2assets/scripts/source_figures.py
+++ b/ResearchStudio-Reel/skills/paper2assets/scripts/source_figures.py
@@ -13,8 +13,11 @@ skip all of that:
   --images <p|url>…  use figures the user attached / linked directly.
 
 Writes assets/figures/*.png + assets/meta/figures.json in the SAME schema as
-extract_pdf.py. Exits 0 if >=1 figure was produced, non-zero otherwise (the
-caller then falls back to the crop pipeline). Never raises on a bad source.
+extract_pdf.py.  If only some TeX figures can be used directly, unresolved or
+multi-file figures are left as explicit ``pdf-crop-pending`` records for
+extract_pdf.py to fill by caption label. Exits 0 if >=1 source figure was
+produced, non-zero otherwise (the caller then falls back to the full crop
+pipeline). Never raises on a bad source.
 
 Text / metadata are unaffected.  TeX captions stay authoritative for source
 figures; PDF-text captions are retained only as alignment candidates.
@@ -181,12 +184,17 @@ def parse_tex_figures(main_tex: Path) -> list[dict]:
         if not incls:
             continue
         cap = ""
-        cm = _CAP.search(body)
-        if cm:
+        # Composite figures commonly contain child ``subfigure`` captions
+        # before the outer Figure caption.  The outer caption/label is the
+        # final pair in normal LaTeX figure structure; using the first pair
+        # misidentifies the whole composite as its first panel.
+        captions = list(_CAP.finditer(body))
+        if captions:
+            cm = captions[-1]
             cap = _clean_caption(_balanced(body, cm.end() - 1))
-        lm = _LABEL.search(body)
+        labels = _LABEL.findall(body)
         out.append({"graphics": incls, "caption": cap,
-                    "label": lm.group(1) if lm else "", "gpaths": gpaths})
+                    "label": labels[-1] if labels else "", "gpaths": gpaths})
     return out
 
 
@@ -344,9 +352,8 @@ def sync_figure_captions(outdir: Path) -> int:
     if not isinstance(figures, list) or not captions:
         return 0
 
-    unused = set(range(len(captions)))
-    aligned = 0
-    for figure in figures:
+    source_captions: dict[int, str] = {}
+    for index, figure in enumerate(figures):
         if not isinstance(figure, dict):
             continue
         source_caption = str(
@@ -354,33 +361,72 @@ def sync_figure_captions(outdir: Path) -> int:
             or (figure.get("caption", "") if figure.get("source") == "original" else "")
             or ""
         )
+        if source_caption:
+            source_captions[index] = source_caption
+
+    # Score the complete matrix before assigning anything.  A greedy
+    # "unused captions" pass can let a later figure inherit its second-best
+    # label after an earlier row consumed the true match.  Require the match
+    # to be uniquely best in both directions instead.
+    row_matches: dict[int, tuple[int, float, float]] = {}
+    for figure_index, source_caption in source_captions.items():
+        ranked = sorted(
+            (
+                (_caption_similarity(source_caption, caption["text"]), caption_index)
+                for caption_index, caption in enumerate(captions)
+            ),
+            key=lambda item: (-item[0], item[1]),
+        )
+        if ranked:
+            score, chosen = ranked[0]
+            second = ranked[1][0] if len(ranked) > 1 else 0.0
+            row_matches[figure_index] = (chosen, score, score - second)
+
+    column_matches: dict[int, tuple[int, float, float]] = {}
+    for caption_index, caption in enumerate(captions):
+        ranked = sorted(
+            (
+                (_caption_similarity(source_caption, caption["text"]), figure_index)
+                for figure_index, source_caption in source_captions.items()
+            ),
+            key=lambda item: (-item[0], item[1]),
+        )
+        if ranked:
+            score, chosen = ranked[0]
+            second = ranked[1][0] if len(ranked) > 1 else 0.0
+            column_matches[caption_index] = (chosen, score, score - second)
+
+    aligned = 0
+    for figure_index, figure in enumerate(figures):
+        if not isinstance(figure, dict):
+            continue
+        source_caption = source_captions.get(figure_index, "")
         chosen: int | None = None
         score = 0.0
         margin = 0.0
-        if source_caption:
-            ranked = sorted(
-                (
-                    (_caption_similarity(source_caption, captions[idx]["text"]), idx)
-                    for idx in unused
-                ),
-                reverse=True,
-            )
-            if ranked:
-                score = ranked[0][0]
-                second = ranked[1][0] if len(ranked) > 1 else 0.0
-                margin = score - second
-                if score >= 0.72 and (len(ranked) == 1 or margin >= 0.08):
-                    chosen = ranked[0][1]
+        reverse_margin = 0.0
+        if figure_index in row_matches:
+            candidate, score, margin = row_matches[figure_index]
+            reverse = column_matches.get(candidate)
+            if reverse:
+                reverse_figure, _, reverse_margin = reverse
+                if (
+                    score >= 0.72
+                    and margin >= 0.08
+                    and reverse_figure == figure_index
+                    and reverse_margin >= 0.08
+                ):
+                    chosen = candidate
         if chosen is None:
             figure["caption_alignment"] = {
-                "method": "source-caption-similarity",
+                "method": "mutual-source-caption-similarity",
                 "status": "unresolved",
                 "confidence": round(score, 3),
                 "margin": round(margin, 3),
+                "reverse_margin": round(reverse_margin, 3),
             }
             continue
 
-        unused.remove(chosen)
         caption = captions[chosen]
         figure["source_caption"] = source_caption
         figure["original_label"] = caption["label"]
@@ -405,10 +451,11 @@ def sync_figure_captions(outdir: Path) -> int:
         )
         figure["caption_candidates"] = candidates
         figure["caption_alignment"] = {
-            "method": "source-caption-similarity",
+            "method": "mutual-source-caption-similarity",
             "status": "aligned",
             "confidence": round(score, 3),
             "margin": round(margin, 3),
+            "reverse_margin": round(reverse_margin, 3),
         }
         aligned += 1
 
@@ -416,12 +463,40 @@ def sync_figure_captions(outdir: Path) -> int:
     return aligned
 
 
-def write_figures(entries: list[tuple[Path, str, str]], outdir: Path) -> int:
-    """entries = [(rasterised_png, caption, label)] in figure order."""
+def write_figures(entries: list[dict], outdir: Path) -> tuple[int, int]:
+    """Write source rasters and pending PDF-fallback records in figure order."""
     figdir = layout.figures_dir(outdir, create=True)
     manifest = []
-    for i, (png, caption, label) in enumerate(entries, 1):
-        final = figdir / f"figure{i}.png"
+    source_count = 0
+    fallback_count = 0
+    for entry in entries:
+        order = int(entry["order"])
+        png = entry.get("png")
+        caption = str(entry.get("caption") or "")
+        label = str(entry.get("label") or "")
+        clabel = f"Figure {order}"
+        common = {
+            "page": 0,
+            "original_label": clabel,
+            "caption_label": clabel,
+            "caption": caption,
+            "caption_candidates": [
+                {"label": label or clabel, "text": caption, "source": "tex"}
+            ],
+            "source_label": label,
+            "source_caption": caption,
+            "source_order": order,
+        }
+        if png is None:
+            manifest.append({
+                **common,
+                "source": "pdf-crop-pending",
+                "fallback_reason": str(entry.get("fallback_reason") or "unresolved-source"),
+            })
+            fallback_count += 1
+            continue
+
+        final = figdir / f"figure{order}.png"
         if png.resolve() != final.resolve():
             shutil.move(str(png), str(final))
         try:
@@ -429,24 +504,19 @@ def write_figures(entries: list[tuple[Path, str, str]], outdir: Path) -> int:
             w, h = Image.open(final).size
         except Exception:
             w = h = 0
-        clabel = f"Figure {i}"
-        cap = caption or ""
         manifest.append({
+            **common,
             "file": f"{layout.FIGURES}/{final.name}",
             "page": 0, "page_width": w, "page_height": h,
             "width": w, "height": h, "column": "full", "num_columns": 1,
-            "original_label": clabel,
-            "caption_label": clabel, "caption": cap,
-            "caption_candidates": [{"label": clabel, "text": cap, "source": "tex"}],
-            "source_label": label,
-            "source_caption": caption,
             "source": "original",
         })
+        source_count += 1
     layout.meta_file(outdir, "figures", create_parent=True).write_text(
         json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
     )
     sync_figure_captions(outdir)
-    return len(manifest)
+    return source_count, fallback_count
 
 
 def main() -> int:
@@ -461,7 +531,7 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
-        entries: list[tuple[Path, str, str]] = []
+        entries: list[dict] = []
 
         if a.images:
             for j, ref in enumerate(a.images, 1):
@@ -470,7 +540,10 @@ def main() -> int:
                     continue
                 png = rasterize(src, tmp / f"img{j}.png", a.dpi)
                 if png is not None:
-                    entries.append((tmp / f"img{j}.png", "", ""))
+                    entries.append({
+                        "png": tmp / f"img{j}.png", "caption": "", "label": "",
+                        "order": len(entries) + 1,
+                    })
         elif a.arxiv:
             aid = _arxiv_id(a.arxiv)
             print(f"[source_figures] arXiv {aid}: downloading source…")
@@ -483,28 +556,59 @@ def main() -> int:
                 print(f"[source_figures] parsed {len(figs)} figure env(s) from {main_tex.name}")
                 for k, fig in enumerate(figs, 1):
                     if len(fig["graphics"]) != 1:
-                        # A caption describing a six-panel composite must not
-                        # be attached to only the first child raster.  The PDF
-                        # crop path can recover the rendered composite safely.
+                        # Keep the figure's exact TeX identity in the manifest.
+                        # extract_pdf.py will align that caption to a printed
+                        # Figure label and replace only this record with the
+                        # rendered composite crop.
                         _eprint(
                             f"[source_figures]   fig{k}: "
                             f"{len(fig['graphics'])} includegraphics entries; "
-                            "skip incomplete source composite"
+                            "defer this composite to PDF crop"
                         )
-                        return 3
+                        entries.append({
+                            "png": None,
+                            "caption": fig["caption"],
+                            "label": fig["label"],
+                            "order": k,
+                            "fallback_reason": f"composite:{len(fig['graphics'])}-graphics",
+                        })
+                        continue
                     ref = fig["graphics"][0]
                     src = _resolve((tmp / "source"), ref, fig["gpaths"])
                     if not src:
                         _eprint(f"[source_figures]   fig{k}: could not resolve {ref}")
+                        entries.append({
+                            "png": None,
+                            "caption": fig["caption"],
+                            "label": fig["label"],
+                            "order": k,
+                            "fallback_reason": "unresolved-graphic",
+                        })
                         continue
                     if rasterize(src, tmp / f"f{k}.png", a.dpi) is not None:
-                        entries.append((tmp / f"f{k}.png", fig["caption"], fig["label"]))
+                        entries.append({
+                            "png": tmp / f"f{k}.png",
+                            "caption": fig["caption"],
+                            "label": fig["label"],
+                            "order": k,
+                        })
+                    else:
+                        entries.append({
+                            "png": None,
+                            "caption": fig["caption"],
+                            "label": fig["label"],
+                            "order": k,
+                            "fallback_reason": "rasterize-failed",
+                        })
             else:                                    # no tex figures -> all graphics
                 gfx = sorted(p for p in (tmp / "source").rglob("*")
                              if p.suffix.lower() in _GRAPHIC_EXT and p.stat().st_size > 2000)
                 for k, src in enumerate(gfx, 1):
                     if rasterize(src, tmp / f"f{k}.png", a.dpi) is not None:
-                        entries.append((tmp / f"f{k}.png", "", ""))
+                        entries.append({
+                            "png": tmp / f"f{k}.png", "caption": "", "label": "",
+                            "order": len(entries) + 1,
+                        })
         else:
             _eprint("[source_figures] need --arxiv or --images")
             return 2
@@ -512,9 +616,19 @@ def main() -> int:
         if not entries:
             _eprint("[source_figures] produced 0 figures — fall back to crop.")
             return 4
-        n = write_figures(entries, outdir)
+        if not any(entry.get("png") is not None for entry in entries):
+            _eprint("[source_figures] produced 0 source figures — fall back to full PDF crop.")
+            return 4
+        source_count, fallback_count = write_figures(entries, outdir)
 
-    print(f"[source_figures] wrote {n} original figure(s) -> {figdir}  (crop loop skipped)")
+    print(f"[source_figures] wrote {source_count} original figure(s) -> {figdir}")
+    if fallback_count:
+        print(
+            f"[source_figures] deferred {fallback_count} figure(s) to selective PDF crop; "
+            "run extract_pdf.py --no-figures to fill them"
+        )
+    else:
+        print("[source_figures] no PDF fallback needed (crop loop skipped)")
     return 0
 
 


### PR DESCRIPTION
## Summary

- preserve clean arXiv source assets when only some TeX figures are composite or unresolved
- defer only those figures to PDF crop, then merge them by mutually unique caption alignment and exact `Figure N` labels
- fail closed on missing, ambiguous, duplicate, or unaligned hybrid records instead of using positional order
- run crop cleanup and visual QA only for final `source: pdf-crop` records
- preserve contiguous numbering for partially successful `--images` inputs

## Validation

- `python -m py_compile` for both modified scripts
- `git diff --check`
- real arXiv/PDF run `2607.04438` (`97520c85-f74c-445b-bf12-61923b63d4a0`): 10 complete records, 8 original source assets, selective PDF fallback for Figure 1 and Figure 10, no pending/missing files
- partial `--images` failure check: the first successful raster remains `figure1.png`