### PR TITLE
Add Trending Paper navigation to the homepage

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -208,6 +208,7 @@ a:hover { text-decoration: underline; text-underline-offset: 3px; }
   font-size: 14.5px;
   font-weight: 500;
   padding: 0;
+  white-space: nowrap;
   border-radius: 0;
   transition: color 0.15s ease;
 }
@@ -216,7 +217,7 @@ a:hover { text-decoration: underline; text-underline-offset: 3px; }
   background: transparent;
   text-decoration: none;
 }
-@media (max-width: 820px) {
+@media (max-width: 1024px) {
   .nav-links { display: none; }
 }
 @media (max-width: 640px) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
     </details>
   </div>
   <div class="topbar-wrap">
-    <nav class="topbar">
+    <nav class="topbar" aria-label="Primary navigation">
       <a class="brand" href="#top">
         <img src="assets/logo.svg" alt="" width="28" height="28" />
         <span>ResearchStudio</span>
@@ -47,6 +47,7 @@
       <ul class="nav-links">
         <li><a href="./idea-page/"><span data-i18n="nav_idea">Explore Idea</span></a></li>
         <li><a href="./reel-page/"><span data-i18n="nav_reel">Explore Reel</span></a></li>
+        <li><a href="./trending-paper/"><span data-i18n="nav_trending">Trending Paper</span></a></li>
       </ul>
       <div class="nav__cta">
         <a class="btn btn--ghost" href="https://github.com/microsoft/ResearchStudio" target="_blank" rel="noopener">
@@ -144,7 +145,7 @@
         en: {
           title: 'ResearchStudio — Your AI co-author, from research problem to publication',
           description: 'ResearchStudio is a collection of Claude Code and Codex skills covering the entire research lifecycle — from a vague research direction to a published paper.',
-          nav_idea: 'Explore Idea', nav_reel: 'Explore Reel', github: 'Open on GitHub', demo: 'Try Demo',
+          nav_idea: 'Explore Idea', nav_reel: 'Explore Reel', nav_trending: 'Trending Paper', github: 'Open on GitHub', demo: 'Try Demo',
           demo_title: 'ResearchStudio Live Demo', demo_description: 'Full ResearchStudio workflow, one unified workspace',
           demo_support: 'Demo hosting supported by NTU.',
           theme_label: 'Theme', theme_light: 'Light', theme_dark: 'Dark',
@@ -159,7 +160,7 @@
         zh: {
           title: 'ResearchStudio — 从研究问题到最终发表的 AI 研究伙伴',
           description: 'ResearchStudio 是覆盖完整科研生命周期的 Claude Code 与 Codex 技能集合——从模糊的研究方向到正式发表的论文。',
-          nav_idea: '探索 Idea', nav_reel: '探索 Reel', github: '在 GitHub 查看', demo: '在线演示',
+          nav_idea: '探索 Idea', nav_reel: '探索 Reel', nav_trending: '热门论文', github: '在 GitHub 查看', demo: '在线演示',
           demo_title: 'ResearchStudio 在线演示', demo_description: '完整 ResearchStudio 工作流,统一工作区',
           demo_support: 'Demo 托管由 NTU 提供支持。',
           theme_label: '主题', theme_light: '浅色', theme_dark: '深色',
@@ -174,7 +175,7 @@
         es: {
           title: 'ResearchStudio — Tu coautor de IA, del problema de investigación a la publicación',
           description: 'ResearchStudio es una colección de habilidades de Claude Code y Codex que cubre todo el ciclo de vida de la investigación, desde una dirección vaga hasta un artículo publicado.',
-          nav_idea: 'Explorar Idea', nav_reel: 'Explorar Reel', github: 'Ver en GitHub', demo: 'Probar demo',
+          nav_idea: 'Explorar Idea', nav_reel: 'Explorar Reel', nav_trending: 'Artículos en tendencia', github: 'Ver en GitHub', demo: 'Probar demo',
           demo_title: 'Demo en vivo de ResearchStudio', demo_description: 'Todo el flujo de ResearchStudio, un solo espacio',
           demo_support: 'Alojamiento de la demo con el apoyo de NTU.',
           theme_label: 'Tema', theme_light: 'Claro', theme_dark: 'Oscuro',


### PR DESCRIPTION
## Summary
- add the Trending Paper entry to the main homepage navigation
- provide matching English, Chinese, and Spanish labels
- align wrapping and the responsive breakpoint with the Idea and Reel page navigation

## Validation
- parsed `docs/index.html` successfully
- verified the homepage-to-Trending Paper route in a local browser preview
- verified the longest Spanish navigation label does not wrap or overflow
- `git diff --check` passes