### PR TITLE
feat(paper2poster): add no-institution header templates

### DIFF
--- a/ResearchStudio-Reel/skills/paper2poster/README.md
+++ b/ResearchStudio-Reel/skills/paper2poster/README.md
@@ -73,9 +73,26 @@ Both orientations are **composed at build time** instead of selecting a monolith
 
 **Venue logo** — `paper2assets` best-effort fetches the conference mark (Wikipedia / Wikidata) into `assets/logos/_venue.png`; the header shows that logo and hides the venue-year text so the two never duplicate. The venue is always the **real conference / journal** — never "arXiv" (a preprint host is not a publication venue).
 
-**Institution logos** — `references/fit_logos.py` packs the institution marks to fill the header zone at a single **uniform height** (every logo enlarges together, sized by the browser's true aspect ratio so even wide SVG wordmarks fit without overflowing the band). Its automatic completion is an allowlist operation: only accepted `logos[]` entries in `assets/logos/logos.json` may be injected, so orphan cover images and rejected or stale marks are not rendered merely because they remain in the directory. Historical `logos[]` entries without approval fields remain compatible. If the manifest is missing, the fitter adds nothing from disk and only preserves explicit HTML sources. `assets/logos/_venue.png` remains a separate conference resource. Landscape headers expose six logo slots; Portrait headers expose four.
+**Institution logos** — `references/fit_logos.py` packs the institution marks to fill the header zone at a single **uniform height** (every logo enlarges together, sized by the browser's true aspect ratio so even wide SVG wordmarks fit without overflowing the band). Its automatic completion is an allowlist operation: only accepted `logos[]` entries in `assets/logos/logos.json` may be injected, so orphan cover images and rejected or stale marks are not rendered merely because they remain in the directory. Historical `logos[]` entries without approval fields remain compatible. If the manifest is missing, the fitter adds nothing from disk and only preserves explicit HTML sources. `assets/logos/_venue.png` remains a separate conference resource. Branded Landscape headers expose six logo slots; branded Portrait headers expose four. The explicit `v6`/`v7` and `pv6`/`pv7` headers expose none.
 
-**QR codes** — in Landscape, the Paper / Code QRs live in the **Scan to Read** section for headers v1–v4; the v5 classic header carries a QR in the title band itself. The **3col layout suppresses Scan-to-Read** and is kept off v5, so a 3col poster carries no QR. Portrait has no standalone Scan-to-Read section and uses only its selected `pv1`–`pv5` header's QR slots.
+**QR codes** — in Landscape, the Paper / Code QRs live in the **Scan to Read** section for headers v1–v4 and v6–v7; the v5 classic header carries a QR in the title band itself. The **3col layout suppresses Scan-to-Read** and is kept off v5, so a 3col poster carries no QR. Portrait has no standalone Scan-to-Read section and uses only its selected `pv1`–`pv7` header's QR slots.
+
+## No institution names or logos
+
+Choose an explicit **Title banner** template rather than relying on a prompt:
+
+| Layout direction | Centered | Left-aligned |
+|---|---|---|
+| Landscape | `--header v6` | `--header v7` |
+| Portrait | `--header pv6` | `--header pv7` |
+
+The Web selector labels these **Clean centered / Clean left · no institutions/logos**.
+They work with every body layout in the chosen orientation. They keep the title,
+plain author names, venue text and normal QR placement, but have no institution
+legend or logo containers. Existing branded templates and random pools are unchanged.
+Fill `{{AUTHORS_PLAIN}}` and follow `references/branding_free_headers.md`; the
+logo fitter respects the explicit opt-out and preflight rejects restored branding.
+This does not anonymize authors or remove text embedded in scientific figures.
 
 ## Deterministic diversity for batches
 
@@ -99,7 +116,7 @@ Every composed HTML embeds the resolved manifest in `#paper2poster-composition` 
 |---|---|---|
 | `POSTER_ORIENTATION` | `landscape` | `landscape` or `portrait` |
 | `POSTER_STYLE` | `random` | Landscape: 1 of 11; Portrait: 1 of 9, excluding `underline` and `double-rule` |
-| `POSTER_HEADER` | `random` | Landscape `v1`–`v5`; Portrait `pv1`–`pv5` |
+| `POSTER_HEADER` | `random` | Branded pool: Landscape `v1`–`v5`, Portrait `pv1`–`pv5`; explicit no institutions/logos: `v6`/`v7`, `pv6`/`pv7` |
 | `POSTER_THEME` | `random` | shared theme: 1 of 9 (`blue` … `mono`) |
 | `POSTER_SEED` | resolved absolute output path | stable seed for ordinary random-axis selection; explicit `--seed` wins |
 | `POSTER_VARIANT_SEED` | ordinary seed | shared batch seed used with `--variant-index` for balanced cycles |

--- a/ResearchStudio-Reel/skills/paper2poster/SKILL.md
+++ b/ResearchStudio-Reel/skills/paper2poster/SKILL.md
@@ -131,6 +131,8 @@ Paper2Assets package, and be rendered again. Cached PDF/PNG existence alone is
 never proof that the Motivation image is correct.
 
 Re-render ONLY when:
+- the user changes the header template, including switching to/from an explicit
+  no-institution header → recompose and re-export instead of reusing the cache
 - one of `poster.{html,pdf,png}` is missing → resume from the
   appropriate step (`poster.html` missing → start from Step 2 fill loop;
   only `poster.pdf` / `poster.png` missing → just run Step 6 render)
@@ -139,6 +141,15 @@ Re-render ONLY when:
   delete `<outdir>/poster.html` first so the cache check doesn't fire.
 
 ### Step 1 — Verify paper2assets prerequisites
+
+**No institution names/logos requested?** Select the explicit unbranded header
+first: Landscape `v6` (centered) / `v7` (left), Portrait `pv6` (centered) / `pv7`
+(left). Read `references/branding_free_headers.md`. For these templates, skip the
+logo recovery below, preserve any shared logo assets, and still recover QR assets
+if needed. Their structure deliberately has no affiliation/logo slots; do not
+add them during substitution or fitting. This exception also applies to all
+later logo-fetching and affiliation instructions. The regular cache shortcut
+does not apply when the requested header differs from the cached poster.
 
 Required argument: an `<outdir>/` path produced by the `paper2assets` skill, or a path to a source `*.pdf`. Verify the required files exist before doing any work:
 
@@ -254,7 +265,7 @@ Both orientations share four independent axes under `assets/`: **layout × style
 
 - **Structure:** landscape `assets/layouts/{full,half,3col}.html`; portrait `assets/layouts_portrait/{full,half}.html`.
 - **Visual style:** `assets/styles/*.css`; Landscape enables all 11 treatments, while Portrait excludes `underline` and `double-rule` and enables the remaining 9.
-- **Titlebar:** landscape `assets/headers/{v1,v2,v3,v4,v5}.html`; portrait `assets/headers_portrait/{pv1,pv2,pv3,pv4,pv5}.html`.
+- **Titlebar:** landscape `assets/headers/{v1,v2,v3,v4,v5,v6,v7}.html`; portrait `assets/headers_portrait/{pv1,pv2,pv3,pv4,pv5,pv6,pv7}.html`. The `*6` / `*7` variants are opt-in, without institution names/logos.
 - **Color/theme:** 9 bundles from `references/apply_theme.py`, shared by both orientations.
 - **Scan-to-Read:** landscape only, from `assets/scan/*.html`.
 
@@ -314,6 +325,13 @@ The first three are **full themes** (they retheme the header + page background);
 
 **Axis 3 — header (`POSTER_HEADER`, default randomize):**
 
+**Explicit no-institution templates:** `v6` / `v7` (Landscape), `pv6` / `pv7`
+(Portrait) omit both institution names and all header logos by construction.
+Choose centered (`*6`) or left-aligned (`*7`); both retain author names, venue
+text and the orientation's normal QR behavior. Fill `{{AUTHORS_PLAIN}}` rather
+than the affiliation-marked `{{AUTHORS}}`. They are excluded from random pools.
+See `references/branding_free_headers.md` for the complete contract.
+
 1. **`v1`** — venue (left) · title (center) · institution logos (right). Symmetric 3-zone band.
 2. **`v2`** — mirror of v1: institution logos (left) · title (center) · venue (right).
 3. **`v3`** — title centered full-width with a single equal-height logo strip below (conference mark + institutions).
@@ -330,7 +348,7 @@ v1–v4 each render the conference **logo** when `assets/logos/_venue.png` exist
 |------|---------|--------------|----------|
 | layout | landscape `full` · `half` · `3col` / portrait `full` · `half` | `assets/layouts/<layout>.html` · `assets/layouts_portrait/<layout>.html` | Method-figure AR / figure count (Axis 1) → `--layout` |
 | style | Landscape: all 11. Portrait: `solid` · `framed` · `simple` · `left-bar` · `elevated` · `neo-brutal` · `tag` · `tinted` · `legend-frame` (9) | `assets/styles/<style>.css` | `POSTER_STYLE` (default random within the orientation catalog) → `--style` |
-| header | landscape `v1`·`v2`·`v3`·`v4`·`v5`(opt-in) / portrait `pv1`·`pv2`·`pv3`·`pv4`·`pv5` | `assets/headers/<v>.html` · `assets/headers_portrait/<pv>.html` | `POSTER_HEADER` (default random) → `--header` |
+| header | landscape `v1`–`v5` / portrait `pv1`–`pv5`; opt-in no institutions/logos: `v6`·`v7` / `pv6`·`pv7` | `assets/headers/<v>.html` · `assets/headers_portrait/<pv>.html` | `POSTER_HEADER` (default random, branded pool only) → `--header` |
 | scan | landscape only: `single` · `dual` (group keywords — recommended) · `aside`(default) · `hero` · `contact` · `directory` · `banner` · `twin` · `chips` | `assets/scan/<variant>.html` | code QR resolves → `--scan dual`, else `--scan single` (Axis 4) → `--scan`; portrait has no scan axis |
 | color/theme | `blue` · `teal` · `green` · `burgundy` · `purple` · `rust` · `slate` · `plum` · `mono` (9 accents) | `references/apply_theme.py` (`THEMES`) | `POSTER_THEME` (default `random`, deterministic per seed) → `--theme`. Applies to landscape and portrait via composition. |
 
@@ -370,11 +388,11 @@ Equivalent Opus-style alternative when you have many substitutions: **copy the r
 
 **Read `references/template_substitution.md` now** — it carries the full placeholder map, the code-driven theme color (1-of-9, applied by compose / `apply_theme.py` — do NOT hand-edit `:root`), per-section accent palette, vertical-sizing convention (in Portrait Half, exactly one `grow` on the bottom-most section of each column), and the **lean initial render policy**: only `Necessary` of the six core sections; all three optional sections (Contribution, Dataset / Benchmark, Ablation Study) and every `Additional` paragraph are deliberately withheld at this stage.
 
-**Decoupled-header + QR placeholder contract (NEW — edge cases).** The following `v1`–`v5` scan-placement rules are for landscape. Portrait always composes one of `pv1`–`pv5`, exposes `{{LOGO_1}}`…`{{LOGO_4}}` plus its header QR placeholders, and has no standalone Scan-to-Read section or scan axis. Fill portrait QR slots only when the referenced QR file exists. The composed headers replace the old titlebar, so the placeholder set changed:
+**Decoupled-header + QR placeholder contract.** Landscape `v6`/`v7` follow the same body-scan rules as `v1`–`v4`. Portrait `pv1`–`pv5` expose `{{LOGO_1}}`…`{{LOGO_4}}` plus header QR placeholders; `pv6`/`pv7` expose only the QR placeholders, with no logo or affiliation slots. All Portrait headers omit the standalone Scan-to-Read section and scan axis. Fill portrait QR slots only when the referenced QR file exists. The composed headers replace the old titlebar, so the placeholder set changed:
 - **Venue:** landscape `v1`–`v4` use `{{VENUE_NAME}}` + `{{VENUE_YEAR}}` and an optional `{{VENUE_LOGO}}`. Set `VENUE_LOGO` to `assets/logos/_venue.png` **only if that file exists**, else `""`; when empty, the header paints the venue/year text in the conference chip. The legacy `{{VENUE}}` token is retired. Landscape `v5` and Portrait `pv1`–`pv5` intentionally keep `{{VENUE_LINK}}` and `{{VENUE_TAG}}` for their compact text badge.
-- **Institution logos:** landscape exposes `{{LOGO_1}}`…`{{LOGO_6}}`; portrait exposes `{{LOGO_1}}`…`{{LOGO_4}}`. Fill each present institution's path; set every **unused** slot to `""` (empty/unfilled chips auto-hide).
+- **Institution logos (branded headers only):** landscape exposes `{{LOGO_1}}`…`{{LOGO_6}}`; portrait exposes `{{LOGO_1}}`…`{{LOGO_4}}`. Fill each present institution's path; set every **unused** slot to `""` (empty/unfilled chips auto-hide).
 - **QR placement depends ONLY on the header — the QR appears in exactly ONE place, and NEVER in the Title Section except for `v5`:**
-  - **Headers `v1` / `v2` / `v3` / `v4` →** the Title Section carries NO QR (these headers have no QR slot at all). ALWAYS fill the standalone **Scan to Read** `.section` (`data-section="scan-to-read"`, right after Takeaway) via `{{QR_PAPER}}` / `{{QR_CODE}}`, and set the header's `{{HDR_QR_PAPER}}` / `{{HDR_QR_CODE}}` to `""`. Institution count is **irrelevant** — the old "≤ 2 institutions → header QR" rule is **RETIRED**; the QR never joins the logo row. The section's **internal layout is the `--scan` axis** (Step 3): pass `--scan dual` when a code QR resolves, else `--scan single`, so a two-QR layout never lands on a one-QR paper. Beyond `{{QR_PAPER}}`/`{{QR_CODE}}`, the picked variant may also expose the display-URL placeholders `{{URL_PAPER}}` / `{{URL_CODE}}` / `{{URL_PROJECT}}` (short URL text from `metadata.json`, e.g. `arxiv.org/abs/2106.09711`) and `{{CONTACT}}` — fill whatever exists and leave the rest `""`; every one auto-hides when empty. **Exception — `--layout 3col`:** the standalone Scan-to-Read section is **suppressed** in the 3col layout (its 1/3-width column is too wide for the section's small content and reads as empty), so a 3col poster intentionally carries **NO QR**. When you compose with `--layout 3col`, leave `{{QR_PAPER}}` / `{{QR_CODE}}` (and the other scan content placeholders) empty — they would render into a hidden section anyway.
+  - **Headers `v1` / `v2` / `v3` / `v4` / `v6` / `v7` →** the Title Section carries NO QR (these headers have no QR slot at all). ALWAYS fill the standalone **Scan to Read** `.section` (`data-section="scan-to-read"`, right after Takeaway) via `{{QR_PAPER}}` / `{{QR_CODE}}`, and set the header's `{{HDR_QR_PAPER}}` / `{{HDR_QR_CODE}}` to `""`. Institution count is **irrelevant** — the old "≤ 2 institutions → header QR" rule is **RETIRED**; the QR never joins the logo row. The section's **internal layout is the `--scan` axis** (Step 3): pass `--scan dual` when a code QR resolves, else `--scan single`, so a two-QR layout never lands on a one-QR paper. Beyond `{{QR_PAPER}}`/`{{QR_CODE}}`, the picked variant may also expose the display-URL placeholders `{{URL_PAPER}}` / `{{URL_CODE}}` / `{{URL_PROJECT}}` (short URL text from `metadata.json`, e.g. `arxiv.org/abs/2106.09711`) and `{{CONTACT}}` — fill whatever exists and leave the rest `""`; every one auto-hides when empty. **Exception — `--layout 3col`:** the standalone Scan-to-Read section is **suppressed** in the 3col layout (its 1/3-width column is too wide for the section's small content and reads as empty), so a 3col poster intentionally carries **NO QR**. When you compose with `--layout 3col`, leave `{{QR_PAPER}}` / `{{QR_CODE}}` (and the other scan content placeholders) empty — they would render into a hidden section anyway.
   - **Header `v5`** (classic) is the ONLY header with a titlebar QR — with `v5`, ALWAYS fill `{{HDR_QR_PAPER}}` / `{{HDR_QR_CODE}}` and leave the section `{{QR_*}}` empty, so the QR shows once (in the v5 header) and the `scan-to-read` section auto-hides.
   - **Render-time guarantee (CSS — belt-and-suspenders, you do NOT rely on the build filling the right one):** every layout hides `.section[data-section="scan-to-read"]` whenever the titlebar carries a FILLED QR (`body:has(.titlebar img.qr-img[filled]) , body:has(.titlebar .qr-tile .chip.qr img[filled]) -> [data-section="scan-to-read"]{display:none}`). So even if BOTH the header QR and the section QR get filled, the standalone Scan-to-Read section is suppressed at render time and the QR can never appear twice.
   - Every QR placeholder auto-hides when empty or when its `assets/qr/*.png` is absent — set a path only if the file exists.

--- a/ResearchStudio-Reel/skills/paper2poster/assets/headers/v6.html
+++ b/ResearchStudio-Reel/skills/paper2poster/assets/headers/v6.html
@@ -1,0 +1,52 @@
+<style>
+  .titlebar.hv-6 {
+    flex: 0 0 auto;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 18pt;
+    padding: 32pt 56pt;
+    background: var(--tb-bg, var(--accent));
+    color: var(--tb-fg, #fff);
+    border: var(--tb-border, none);
+    border-radius: var(--tb-radius, 12pt);
+    box-shadow: var(--tb-shadow, none);
+    text-align: center;
+  }
+  .titlebar.hv-6 .title-block { min-width: 0; width: 100%; text-align: center; }
+  .titlebar.hv-6 h1 {
+    margin: 0 0 0.2em;
+    font-size: 84pt;
+    line-height: 1.1;
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    color: var(--tb-title-fg, var(--tb-fg, #fff));
+  }
+  .titlebar.hv-6 .authors { font-size: 40pt; line-height: 1.3; }
+  .titlebar.hv-6 .venue-text { font-size: 28pt; line-height: 1.2; opacity: 0.8; }
+  .titlebar.hv-6 .venue-text:not(:has(span:not(:empty))) { display: none; }
+  .titlebar.hv-6 .listen-all {
+    position: absolute;
+    bottom: 16pt;
+    left: 48pt;
+    z-index: 5;
+    font-size: 26pt;
+    font-weight: 600;
+    color: inherit;
+    background: transparent;
+    border: 1.5pt solid currentColor;
+    border-radius: 999px;
+    height: 66pt;
+    padding: 0 18pt;
+    cursor: pointer;
+  }
+</style>
+<header class="titlebar hv-6" data-section="title" data-header="v6" data-institution-branding="none">
+  <div class="title-block">
+    <h1>{{TITLE}}</h1>
+    <div class="authors">{{AUTHORS_PLAIN}}</div>
+  </div>
+  <div class="venue-text"><span>{{VENUE_NAME}}</span> <span>{{VENUE_YEAR}}</span></div>
+  <button class="listen-all" data-listen-all>Full Listen</button>
+</header>

--- a/ResearchStudio-Reel/skills/paper2poster/assets/headers/v7.html
+++ b/ResearchStudio-Reel/skills/paper2poster/assets/headers/v7.html
@@ -1,0 +1,61 @@
+<style>
+  .titlebar.hv-7 {
+    flex: 0 0 auto;
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 48pt;
+    padding: 32pt 56pt;
+    background: var(--tb-bg, var(--accent));
+    color: var(--tb-fg, #fff);
+    border: var(--tb-border, none);
+    border-radius: var(--tb-radius, 12pt);
+    box-shadow: var(--tb-shadow, none);
+  }
+  .titlebar.hv-7 .title-block { min-width: 0; text-align: left; }
+  .titlebar.hv-7 h1 {
+    margin: 0 0 0.2em;
+    font-size: 84pt;
+    line-height: 1.1;
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    color: var(--tb-title-fg, var(--tb-fg, #fff));
+  }
+  .titlebar.hv-7 .authors { font-size: 40pt; line-height: 1.3; }
+  .titlebar.hv-7 .venue-text {
+    max-width: 440pt;
+    padding-left: 32pt;
+    border-left: 2pt solid currentColor;
+    font-size: 32pt;
+    line-height: 1.25;
+    text-align: right;
+    overflow-wrap: anywhere;
+  }
+  .titlebar.hv-7 .venue-text span { display: block; }
+  .titlebar.hv-7 .venue-text:not(:has(span:not(:empty))) { display: none; }
+  .titlebar.hv-7:not(:has(.venue-text span:not(:empty))) { grid-template-columns: minmax(0, 1fr); }
+  .titlebar.hv-7 .listen-all {
+    position: absolute;
+    bottom: 16pt;
+    right: 48pt;
+    z-index: 5;
+    font-size: 26pt;
+    font-weight: 600;
+    color: inherit;
+    background: transparent;
+    border: 1.5pt solid currentColor;
+    border-radius: 999px;
+    height: 66pt;
+    padding: 0 18pt;
+    cursor: pointer;
+  }
+</style>
+<header class="titlebar hv-7" data-section="title" data-header="v7" data-institution-branding="none">
+  <div class="title-block">
+    <h1>{{TITLE}}</h1>
+    <div class="authors">{{AUTHORS_PLAIN}}</div>
+  </div>
+  <div class="venue-text"><span>{{VENUE_NAME}}</span><span>{{VENUE_YEAR}}</span></div>
+  <button class="listen-all" data-listen-all>Full Listen</button>
+</header>

--- a/ResearchStudio-Reel/skills/paper2poster/assets/headers_portrait/pv6.html
+++ b/ResearchStudio-Reel/skills/paper2poster/assets/headers_portrait/pv6.html
@@ -1,0 +1,45 @@
+<style>
+  .titlebar.pv6 {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas: "tt" "mr";
+    gap: 18pt;
+  }
+  .titlebar.pv6 .title-block { width: 100%; text-align: center; }
+  .titlebar.pv6 .meta-rail {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    flex-direction: row;
+    justify-content: center;
+    gap: 32pt;
+  }
+  .titlebar.pv6 .venue-badge { width: auto; max-width: 480pt; }
+  .titlebar.pv6 .venue-badge .vb-venue { font-size: 36pt; }
+  .titlebar.pv6 .venue-badge .vb-year { font-size: 24pt; }
+  .titlebar.pv6 .qr-block { flex-direction: row; gap: 24pt; }
+  .titlebar.pv6 .qr-block .qr-img { width: 108pt; height: 108pt; }
+  .titlebar.pv6 .qr-block .qr-label { font-size: 20pt; }
+  .titlebar.pv6:not(:has(.vb-venue:not(:empty), .vb-year:not(:empty), .qr-img[src]:not([src=""]):not([src*="{{"]))) {
+    grid-template-areas: "tt";
+  }
+  .titlebar.pv6:not(:has(.vb-venue:not(:empty), .vb-year:not(:empty), .qr-img[src]:not([src=""]):not([src*="{{"]))) .meta-rail { display: none; }
+</style>
+<header class="titlebar pv6" data-section="title" data-header="pv6" data-institution-branding="none">
+  <div class="title-block">
+    <h1>{{TITLE}}</h1>
+    <div class="authors">{{AUTHORS_PLAIN}}</div>
+  </div>
+  <div class="meta-rail" data-section="header-meta">
+    <div class="venue-badge">
+      <a class="vb-link" href="{{VENUE_LINK}}" target="_blank" rel="noopener">
+        <div class="vb-venue">{{VENUE_NAME}}</div>
+        <div class="vb-year">{{VENUE_YEAR}}</div>
+      </a>
+    </div>
+    <div class="qr-block">
+      <figure class="qr"><img class="qr-img" src="{{QR_PAPER}}" alt="Paper QR" onerror="this.parentElement.remove()"><figcaption class="qr-label">Paper</figcaption></figure>
+      <figure class="qr"><img class="qr-img" src="{{QR_CODE}}" alt="Code QR" onerror="this.parentElement.remove()"><figcaption class="qr-label">Code</figcaption></figure>
+    </div>
+  </div>
+  <button class="listen-all" data-listen-all>Full Listen</button>
+</header>

--- a/ResearchStudio-Reel/skills/paper2poster/assets/headers_portrait/pv7.html
+++ b/ResearchStudio-Reel/skills/paper2poster/assets/headers_portrait/pv7.html
@@ -1,0 +1,46 @@
+<style>
+  .titlebar.pv7 {
+    grid-template-columns: minmax(0, 1fr) 300pt;
+    grid-template-areas: "tt mr";
+    gap: 32pt;
+  }
+  .titlebar.pv7 .title-block { align-self: center; text-align: left; }
+  .titlebar.pv7 .meta-rail {
+    margin: 0;
+    padding: 0 0 0 24pt;
+    border: 0;
+    border-left: 2pt solid var(--tb-divider, currentColor);
+    justify-content: center;
+    gap: 20pt;
+  }
+  .titlebar.pv7 .venue-badge { width: 100%; }
+  .titlebar.pv7 .venue-badge .vb-venue { font-size: 36pt; }
+  .titlebar.pv7 .venue-badge .vb-year { font-size: 24pt; }
+  .titlebar.pv7 .qr-block { flex-direction: row; gap: 18pt; }
+  .titlebar.pv7 .qr-block .qr-img { width: 108pt; height: 108pt; }
+  .titlebar.pv7 .qr-block .qr-label { font-size: 20pt; }
+  .titlebar.pv7:not(:has(.vb-venue:not(:empty), .vb-year:not(:empty), .qr-img[src]:not([src=""]):not([src*="{{"]))) {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas: "tt";
+  }
+  .titlebar.pv7:not(:has(.vb-venue:not(:empty), .vb-year:not(:empty), .qr-img[src]:not([src=""]):not([src*="{{"]))) .meta-rail { display: none; }
+</style>
+<header class="titlebar pv7" data-section="title" data-header="pv7" data-institution-branding="none">
+  <div class="title-block">
+    <h1>{{TITLE}}</h1>
+    <div class="authors">{{AUTHORS_PLAIN}}</div>
+  </div>
+  <div class="meta-rail" data-section="header-meta">
+    <div class="venue-badge">
+      <a class="vb-link" href="{{VENUE_LINK}}" target="_blank" rel="noopener">
+        <div class="vb-venue">{{VENUE_NAME}}</div>
+        <div class="vb-year">{{VENUE_YEAR}}</div>
+      </a>
+    </div>
+    <div class="qr-block">
+      <figure class="qr"><img class="qr-img" src="{{QR_PAPER}}" alt="Paper QR" onerror="this.parentElement.remove()"><figcaption class="qr-label">Paper</figcaption></figure>
+      <figure class="qr"><img class="qr-img" src="{{QR_CODE}}" alt="Code QR" onerror="this.parentElement.remove()"><figcaption class="qr-label">Code</figcaption></figure>
+    </div>
+  </div>
+  <button class="listen-all" data-listen-all>Full Listen</button>
+</header>

--- a/ResearchStudio-Reel/skills/paper2poster/references/branding_free_headers.md
+++ b/ResearchStudio-Reel/skills/paper2poster/references/branding_free_headers.md
@@ -1,0 +1,56 @@
+# Headers without institution names or logos
+
+Use an explicit header template, not a prompt asking the model to delete logos.
+These templates apply to any body layout in their orientation; there is no need
+to duplicate the column layouts.
+
+| Orientation | `--header` | Web label | Structure |
+|---|---|---|---|
+| Landscape | `v6` | Clean centered · no institutions/logos | Full-width centered title and authors; venue text below |
+| Landscape | `v7` | Clean left · no institutions/logos | Left-aligned title and authors; venue text on the right |
+| Portrait | `pv6` | Clean centered · no institutions/logos | Full-width centered title and authors; venue text and QR row below |
+| Portrait | `pv7` | Clean left · no institutions/logos | Left-aligned title and authors; compact venue/QR rail on the right |
+
+All four omit institution names, affiliation legends, institution logos,
+conference logos and contact lines from the header. They retain the paper title
+and author names. Venue text and available Paper/Code QR tiles are not logos and
+remain supported. Landscape follows the existing Scan-to-Read placement rules:
+`3col` has no QR; other layouts use their body scan section. Portrait keeps its
+QR tiles in the header. Missing venue/QR content collapses without leaving an
+empty branding rail.
+
+## Selection
+
+- For “不要机构名和 logo”, “no affiliations/logos”, or equivalent requests,
+  choose `v6` for Landscape or `pv6` for Portrait unless left alignment is wanted.
+- `--header random` and the portal's Auto option intentionally retain the existing
+  branded pools (`v1`–`v5` / `pv1`–`pv5`). Unbranded headers are opt-in; explicit
+  choices also stay fixed when other axes use random/batch selection.
+- Keep the template's `data-institution-branding="none"` marker and structure.
+  Never restore a logo zone or institution legend, even when upstream logo assets
+  already exist. Do not delete those shared assets: other outputs may need them.
+- Fill `{{AUTHORS_PLAIN}}` with **names only**, in paper order, with no institution
+  names, superscripts, affiliation indices or contribution/correspondence markers.
+  Do not reuse the marked-up `{{AUTHORS}}` value. The new headers have no
+  `{{AUTHOR_LEGEND}}`, `{{CONTACT}}`, `{{LOGO_n}}` or `{{VENUE_LOGO}}` slots.
+- Skip logo fetching/recovery for this poster. Still run `fit_logos.py`: it skips
+  logo auto-completion for these headers but retains QR labelling/normalization.
+  Run preflight after filling and fitting; it rejects reintroduced logo markup,
+  affiliation containers and author superscripts in an unbranded header.
+- If a cached poster uses another header, explicitly rebuild it and re-export
+  HTML/PDF/PNG/PPTX rather than returning the stale branded outputs.
+
+This is a presentation choice, **not anonymous-review redaction**. Authors,
+paper links, scientific figures and research text remain; institution names
+inside source figures or the paper title are not scrubbed.
+
+```bash
+python references/compose_poster.py --orientation landscape \
+  --layout half --header v6 --style solid --theme blue --out <outdir>/poster.html
+python references/compose_poster.py --orientation portrait \
+  --layout half --header pv7 --style simple --theme teal --out <outdir>/poster.html
+```
+
+Continue with `references/build_poster.py` and the normal measured-fill/export
+workflow. `POSTER_HEADER=v6|v7|pv6|pv7` is also supported by the CLI; keep the
+chosen orientation compatible with the header.

--- a/ResearchStudio-Reel/skills/paper2poster/references/build_poster.py
+++ b/ResearchStudio-Reel/skills/paper2poster/references/build_poster.py
@@ -63,6 +63,7 @@ SUBS = {
     # titlebar / metadata
     "{{TITLE}}":         "...",
     "{{AUTHORS}}":       "...",
+    "{{AUTHORS_PLAIN}}": "...",
     "{{AUTHOR_LEGEND}}": "...",   # e.g. '<sup>1</sup> MIT &nbsp;&nbsp; <sup>2</sup> NUS'
     "{{VENUE}}":         "...",
     "{{VENUE_NAME}}":    "...",

--- a/ResearchStudio-Reel/skills/paper2poster/references/compose_poster.py
+++ b/ResearchStudio-Reel/skills/paper2poster/references/compose_poster.py
@@ -7,7 +7,7 @@ The poster source is decoupled into orientation-aware pieces under <skill>/asset
                             with a {{HEADER}} hook in <body> and a {{STYLE_CSS}}
                             hook in <head>.
     styles/<style>.css      VISUAL     — one of the installed card treatments.
-    headers*/<header>.html  TITLEBAR   — landscape v1..v5 or Portrait pv1..pv5.
+    headers*/<header>.html  TITLEBAR   — landscape v1..v7 or Portrait pv1..pv7.
 
 compose(layout, style, header, outpath) reads the layout, injects the style CSS at
 {{STYLE_CSS}} and the header HTML at {{HEADER}}, and writes ONE self-contained
@@ -67,6 +67,7 @@ MATH_ENGINES = ("katex", "mathjax")
 # narrow columns. Keep their source CSS installed for Landscape, but remove them
 # from Portrait's catalog so neither random nor explicit selection can use them.
 PORTRAIT_EXCLUDED_STYLES = frozenset({"underline", "double-rule"})
+BRANDING_FREE_HEADERS = frozenset({"v6", "v7", "pv6", "pv7"})
 
 # Batch sampler v4 resolves every requested random axis JOINTLY.  The previous
 # sampler balanced each axis in isolation, which made every marginal look good
@@ -327,8 +328,11 @@ def compose(layout: str, style: str, header: str, outpath, *,
     rewrite the :root accent vars in place. Returns the output Path.
 
     ``orientation`` = ``landscape`` (default) reads assets/layouts/ and composes
-    all axes. ``portrait`` reads assets/layouts_portrait/, uses pv1-pv5 headers,
+    all axes. ``portrait`` reads assets/layouts_portrait/, uses pv1-pv7 headers,
     and omits only the Scan-to-Read body section. Exits non-zero on any error.
+
+    v6/v7 and pv6/pv7 omit institution names and logos. They are explicit-only;
+    random selection retains the existing branded header catalog.
 
     Random selection is deterministic. The seed precedence is explicit ``seed``,
     ``POSTER_SEED``, then the resolved absolute output path. For a 30+ paper batch,
@@ -375,7 +379,8 @@ def compose(layout: str, style: str, header: str, outpath, *,
         "layouts": [o for o in _options(layouts, ".html")
                     if o not in ("methoddriven", "methoddriven4")],
         "styles": orientation_styles,
-        "headers": _options(headers, ".html"),
+        "headers": [name for name in _options(headers, ".html")
+                    if name not in BRANDING_FREE_HEADERS],
         "themes": sorted(apply_theme.THEMES),
     }
 
@@ -625,7 +630,8 @@ def main(argv: list[str] | None = None) -> int:
                     help="visual style name or random (default POSTER_STYLE or random)")
     ap.add_argument("--header", default=os.environ.get("POSTER_HEADER", "random"),
                     help="titlebar variant (default POSTER_HEADER or random): landscape v1-v5, "
-                         "portrait pv1-pv5")
+                         "portrait pv1-pv5; opt-in no institutions/logos: "
+                         "v6/v7 (landscape), pv6/pv7 (portrait)")
     ap.add_argument("--scan", default="aside",
                     help="Scan-to-Read variant: single | dual (group keyword — "
                          "recommended; compose picks within the group) | random | "
@@ -642,7 +648,7 @@ def main(argv: list[str] | None = None) -> int:
                     choices=("landscape", "portrait"),
                     help="landscape (default POSTER_ORIENTATION; 4 axes) | "
                          "portrait (layouts_portrait/, "
-                         "pv1-pv5 titlebar, no scan section)")
+                         "pv1-pv7 titlebar, no scan section)")
     ap.add_argument("--seed", default=None,
                     help="stable seed for random axes (default: POSTER_SEED or the "
                          "resolved absolute --out path)")

--- a/ResearchStudio-Reel/skills/paper2poster/references/fit_logos.py
+++ b/ResearchStudio-Reel/skills/paper2poster/references/fit_logos.py
@@ -640,11 +640,17 @@ def bake(poster_path, max_rows=3, pad_frac=0.06):
                                           # zone sizes differently under screen vs print media,
                                           # so measure the SAME layout the final PDF/PNG uses.
         pg.goto(poster.as_uri()); pg.wait_for_timeout(600)
+        branding_hidden = pg.locator(
+            '.titlebar[data-institution-branding="none"]'
+        ).count() > 0
+        if branding_hidden:
+            approved_logos = []
+            approved_srcs = []
         # Venue inject: if the venue logo file exists on disk but the header isn't showing
         # it (the <img> was left empty, or its onerror="this.remove()" already fired on the
         # empty src), (re)create the venue <img> in the conference chip and point it at the
         # file. Only acts when the chip has no real logo yet — never overrides a good one.
-        if (base / "assets" / "logos" / "_venue.png").exists():
+        if not branding_hidden and (base / "assets" / "logos" / "_venue.png").exists():
             # Insert the venue <img> INTO the conference chip (.chip.conf), never its
             # .venue-mark parent. The vtext-hide CSS keys off `.chip.conf:has(img[src])`,
             # so an <img> placed in the parent leaves the chip "logo-less" and the year

--- a/ResearchStudio-Reel/skills/paper2poster/references/template_substitution.md
+++ b/ResearchStudio-Reel/skills/paper2poster/references/template_substitution.md
@@ -4,6 +4,13 @@ How to fill a composed `poster.html` with values pulled from `paper_spec.md`. Re
 
 ## Template selection
 
+For an explicit no-institution/no-logo poster, select `v6` / `v7` (Landscape)
+or `pv6` / `pv7` (Portrait). See `branding_free_headers.md`. These templates
+use `{{AUTHORS_PLAIN}}` (names only, no superscripts or affiliation/role markers)
+and expose **no** author-legend, contact or logo slots. The affiliation/logo
+instructions below apply only to branded headers. Never re-add those absent
+slots; extra SUBS keys are ignored. Venue text and QR codes remain supported.
+
 Choose the orientation explicitly, then drive the layout by the Method figure's column width and aspect ratio.
 
 | Orientation / figure | Composed layout |
@@ -14,7 +21,7 @@ Choose the orientation explicitly, then drive the layout by the Method figure's 
 | Portrait `{column=full}` or AR ≥ 1.2 | `assets/layouts_portrait/full.html`, four content bands: Problem\|Motivation, Method hero, Key Results\|Ablation\|Headline Numbers at `1.5fr 1fr 1fr`, then full-width Takeaway |
 | `**Figure:** none` | Compose `--layout half` for the chosen orientation, then remove the Method `<figure>` block |
 
-All layouts share placeholder tokens, audio markup, keybinding scripts, and design tokens. Always create the working file with `references/compose_poster.py`; it injects layout, style, theme, and a real header (`v1`–`v5` landscape or `pv1`–`pv5` portrait). Portrait has no standalone Scan-to-Read section or scan axis, but it still has a composed header. Then apply substitutions with the Edit tool one `{{...}}` token at a time. **Never write the full file inline** because the ~100 KB template overflows the per-turn output-token cap. For many substitutions at once, copy the **`build_poster.py` skeleton in this folder** to `<outdir>/assets/meta/build_poster.py`, fill its `SUBS` dict, and run `python <outdir>/assets/meta/build_poster.py <outdir>/poster.html`. Do not edit the generated CSS, JS, or structural markup.
+All layouts share placeholder tokens, audio markup, keybinding scripts, and design tokens. Always create the working file with `references/compose_poster.py`; it injects layout, style, theme, and a real header (`v1`–`v7` landscape or `pv1`–`pv7` portrait). Portrait has no standalone Scan-to-Read section or scan axis, but it still has a composed header. Then apply substitutions with the Edit tool one `{{...}}` token at a time. **Never write the full file inline** because the ~100 KB template overflows the per-turn output-token cap. For many substitutions at once, copy the **`build_poster.py` skeleton in this folder** to `<outdir>/assets/meta/build_poster.py`, fill its `SUBS` dict, and run `python <outdir>/assets/meta/build_poster.py <outdir>/poster.html`. Do not edit the generated CSS, JS, or structural markup.
 
 Before substituting any figure placeholder, run `scripts/select_figures.py
 <outdir>` and read `<outdir>/assets/meta/figure_selection.json`. New semantic

--- a/ResearchStudio-Reel/skills/paper2poster/scripts/utils/preflight.py
+++ b/ResearchStudio-Reel/skills/paper2poster/scripts/utils/preflight.py
@@ -114,6 +114,65 @@ class _FigureUsageParser(HTMLParser):
                 return
 
 
+class _BrandingFreeHeaderParser(HTMLParser):
+    """Reject branding accidentally restored to an explicitly unbranded header."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.stack: list[tuple[str, bool, bool]] = []
+        self.problems: list[str] = []
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]],
+    ) -> None:
+        attributes = dict(attrs)
+        classes = set((attributes.get("class") or "").split())
+        in_header = self.stack[-1][1] if self.stack else False
+        in_authors = self.stack[-1][2] if self.stack else False
+        if tag == "header":
+            in_header = (
+                attributes.get("data-institution-branding") == "none"
+                or attributes.get("data-header") in {"v6", "v7", "pv6", "pv7"}
+            )
+        in_authors = in_authors or "authors" in classes
+        if in_header:
+            forbidden_classes = classes.intersection({
+                "author-legend", "institutes-line", "institution-rail",
+                "logo", "logo-block", "logo-grid", "venue-mark", "affiliations",
+            })
+            logo_image = tag == "img" and (
+                "qr-img" not in classes
+                or "/logos/" in (attributes.get("src") or "").replace("\\", "/")
+            )
+            if forbidden_classes or logo_image or (in_authors and tag == "sup"):
+                self.problems.append(
+                    f"L{self.getpos()[0]}: branding-free header contains institution "
+                    "markup, a logo, or author markers; keep only plain author "
+                    "names, venue text and optional QR tiles"
+                )
+        if tag not in _VOID_ELEMENTS:
+            self.stack.append((tag, in_header, in_authors))
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]],
+    ) -> None:
+        self.handle_starttag(tag, attrs)
+        if tag not in _VOID_ELEMENTS:
+            self.handle_endtag(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        for index in range(len(self.stack) - 1, -1, -1):
+            if self.stack[index][0] == tag:
+                del self.stack[index:]
+                return
+
+
+def _branding_free_header_lint(raw: str) -> list[str]:
+    parser = _BrandingFreeHeaderParser()
+    parser.feed(raw)
+    return parser.problems
+
+
 def _usage_role(section_id: str) -> str | None:
     section = section_id.strip().lower().replace("_", "-")
     if section == "motivation":
@@ -378,7 +437,7 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     raw = html_path.read_text(encoding="utf-8", errors="ignore")
     body = strip_for_lint(raw)
 
-    problems: list[str] = []
+    problems: list[str] = _branding_free_header_lint(raw)
     warnings: list[str] = []
 
     # 0) Figure-to-section semantics.  New paper2assets bundles carry an


### PR DESCRIPTION
## Summary
- Add opt-in, centered and left-aligned headers without institution names or logos: Landscape `v6` / `v7` and Portrait `pv6` / `pv7`.
- Keep plain author names, venue text, and existing QR placement while leaving branded templates and random-selection pools unchanged.
- Prevent logo auto-completion for these headers and reject restored affiliation/logo markup during preflight.
- Document explicit template selection, plain-author substitution, and cached-poster rebuild behavior.

## Validation
- Local regression suite against the current main branches: 38 passing tests; test files are not included in this PR.
- Browser checks: 32 passing checks covering screen/print rendering, A0/5:3 canvases, and missing venue/QR content.
- Whitespace validation passes.

## Scope
Companion Web selector and preview PR: https://github.com/ai-nuts/researchstudio-web-portal/pull/5

Only the canonical Paper2Poster Skill is changed. Local preview exports, unrelated workspace changes, and test files are excluded.
